### PR TITLE
#214 fix: 🐛 Scroll position now persists when open/closing options

### DIFF
--- a/packages/foundry-react-ui/src/components/Dropdown/Dropdown.stories.tsx
+++ b/packages/foundry-react-ui/src/components/Dropdown/Dropdown.stories.tsx
@@ -94,6 +94,7 @@ storiesOf('Dropdown', module)
                 setValues(selected);
               }}
               options={cities}
+              rememberScrollPosition={boolean('rememberScrollPosition', true)}
               variant={select('variant', variants, variants.outline)}
               optionsVariant={select('optionsVariant', variants, variants.outline)}
               valueVariant={select('valueVariant', variants, variants.text)}


### PR DESCRIPTION
Optionally, based on rememberScrollPosition, the dropdown options box will scroll to where it was previously scrolled to. This is useful in many standard cases, but when dynamic options are being passed in, remembering the scroll position can be harmful to the UX - hence the optional prop.

✅ Closes: #214
