### PR TITLE
#212 docs: ✏️ Format docs table to make component code more readable

### DIFF
--- a/packages/foundry-react-ui/.storybook/docPagesStyle.css
+++ b/packages/foundry-react-ui/.storybook/docPagesStyle.css
@@ -1,11 +1,18 @@
-.docblock-propstable th:first-of-type {
-    width: 20%;
+.docblock-propstable th:first-child,
+.docblock-propstable td:first-child {
+  width: 20%;
 }
 
-.docblock-propstable th:nth-of-type(2) {
-    width: 20%;
+.docblock-propstable th:nth-child(2),
+.docblock-propstable th:nth-child(2) {
+  width: 20%;
 }
 
-.docblock-propstable th:last-of-type {
-    width: 60% !important;
+.docblock-propstable th:last-child,
+.docblock-propstable td:last-child {
+  width: 60% !important;
+}
+
+.docblock-propstable td:last-child span {
+  white-space: pre;
 }


### PR DESCRIPTION
pre-wrapping the styled-components subcomonent definition in the prop
table makes it much easier to read

✅ Closes: #212
