### PR TITLE
#233 Set layout containment for Card component

### DIFF
--- a/src/components/Button/__tests__/__snapshots__/Button.test.tsx.snap
+++ b/src/components/Button/__tests__/__snapshots__/Button.test.tsx.snap
@@ -34,6 +34,7 @@ exports[`Button keeps the container the same when switching between isLoading an
   border-radius: 0.25em;
   -webkit-transition: background-color .2s, color .5s, outline .5s, filter .5s, box-shadow .5s;
   transition: background-color .2s, color .5s, outline .5s, filter .5s, box-shadow .5s;
+  contain: layout;
   outline: 0 none;
   border: 0 none;
   cursor: pointer;
@@ -114,6 +115,7 @@ exports[`Button keeps the container the same when switching between isLoading an
   border-radius: 0.25em;
   -webkit-transition: background-color .2s, color .5s, outline .5s, filter .5s, box-shadow .5s;
   transition: background-color .2s, color .5s, outline .5s, filter .5s, box-shadow .5s;
+  contain: layout;
   outline: 0 none;
   border: 0 none;
   cursor: pointer;
@@ -185,6 +187,7 @@ exports[`Button shows ButtonContainer ButtonVariant.fill 1`] = `
   border-radius: 0.25em;
   -webkit-transition: background-color .2s, color .5s, outline .5s, filter .5s, box-shadow .5s;
   transition: background-color .2s, color .5s, outline .5s, filter .5s, box-shadow .5s;
+  contain: layout;
   outline: 0 none;
   border: 0 none;
   cursor: pointer;
@@ -257,6 +260,7 @@ exports[`Button shows ButtonContainer ButtonVariant.outline 1`] = `
   border-radius: 0.25em;
   -webkit-transition: background-color .2s, color .5s, outline .5s, filter .5s, box-shadow .5s;
   transition: background-color .2s, color .5s, outline .5s, filter .5s, box-shadow .5s;
+  contain: layout;
   outline: 0 none;
   border: 1px solid #7c8186;
   cursor: pointer;
@@ -329,6 +333,7 @@ exports[`Button shows ButtonContainer ButtonVariant.text 1`] = `
   border-radius: 0.25em;
   -webkit-transition: background-color .2s, color .5s, outline .5s, filter .5s, box-shadow .5s;
   transition: background-color .2s, color .5s, outline .5s, filter .5s, box-shadow .5s;
+  contain: layout;
   outline: 0 none;
   border: 0 none;
   cursor: pointer;
@@ -401,6 +406,7 @@ exports[`Button shows ButtonContainer with nondefault props variant and color 1`
   border-radius: 0.25em;
   -webkit-transition: background-color .2s, color .5s, outline .5s, filter .5s, box-shadow .5s;
   transition: background-color .2s, color .5s, outline .5s, filter .5s, box-shadow .5s;
+  contain: layout;
   -webkit-filter: drop-shadow(0rem 0.07082177831667665rem 0.5rem rgba(39,47,78,0.39738511585523156));
   filter: drop-shadow(0rem 0.07082177831667665rem 0.5rem rgba(39,47,78,0.39738511585523156));
   outline: 0 none;
@@ -475,6 +481,7 @@ exports[`Button shows LeftIconContainer when isProcessing 1`] = `
   border-radius: 0.25em;
   -webkit-transition: background-color .2s, color .5s, outline .5s, filter .5s, box-shadow .5s;
   transition: background-color .2s, color .5s, outline .5s, filter .5s, box-shadow .5s;
+  contain: layout;
   outline: 0 none;
   border: 0 none;
   cursor: pointer;
@@ -578,6 +585,7 @@ exports[`Button shows icons 1`] = `
   border-radius: 0.25em;
   -webkit-transition: background-color .2s, color .5s, outline .5s, filter .5s, box-shadow .5s;
   transition: background-color .2s, color .5s, outline .5s, filter .5s, box-shadow .5s;
+  contain: layout;
   outline: 0 none;
   border: 0 none;
   cursor: pointer;
@@ -681,6 +689,7 @@ exports[`Button shows icons with type string 1`] = `
   border-radius: 0.25em;
   -webkit-transition: background-color .2s, color .5s, outline .5s, filter .5s, box-shadow .5s;
   transition: background-color .2s, color .5s, outline .5s, filter .5s, box-shadow .5s;
+  contain: layout;
   outline: 0 none;
   border: 0 none;
   cursor: pointer;
@@ -797,6 +806,7 @@ exports[`Button shows loading text when provided 1`] = `
   border-radius: 0.25em;
   -webkit-transition: background-color .2s, color .5s, outline .5s, filter .5s, box-shadow .5s;
   transition: background-color .2s, color .5s, outline .5s, filter .5s, box-shadow .5s;
+  contain: layout;
   outline: 0 none;
   border: 0 none;
   cursor: pointer;

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -25,6 +25,7 @@ export const CardContainer = styled(Div)`
     const { colors } = useTheme();
 
     return `
+      contain: layout;
       ${onClick !== defaultOnClick ? 'cursor: pointer;' : ''}
       display: inline-flex;
       flex-flow: column nowrap;

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -25,7 +25,6 @@ export const CardContainer = styled(Div)`
     const { colors } = useTheme();
 
     return `
-      contain: layout;
       ${onClick !== defaultOnClick ? 'cursor: pointer;' : ''}
       display: inline-flex;
       flex-flow: column nowrap;

--- a/src/components/Card/__tests__/__snapshots__/Card.test.tsx.snap
+++ b/src/components/Card/__tests__/__snapshots__/Card.test.tsx.snap
@@ -13,6 +13,7 @@ exports[`Card header bottom padding should be 0rem when body is present 1`] = `
 }
 
 .c0 {
+  contain: layout;
   cursor: pointer;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -94,6 +95,7 @@ exports[`Card header bottom padding should be 0rem when footer is present 1`] = 
 }
 
 .c0 {
+  contain: layout;
   cursor: pointer;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -187,6 +189,7 @@ exports[`Card header bottom padding should be 1.5rem without body and footer 1`]
 }
 
 .c0 {
+  contain: layout;
   cursor: pointer;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -258,6 +261,7 @@ exports[`Card shows Card with default feedback 1`] = `
 }
 
 .c0 {
+  contain: layout;
   cursor: pointer;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -317,6 +321,7 @@ exports[`Card shows Card with default props 1`] = `
 }
 
 .c0 {
+  contain: layout;
   cursor: pointer;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -376,6 +381,7 @@ exports[`Card shows Card with non-default elevation 1`] = `
 }
 
 .c0 {
+  contain: layout;
   cursor: pointer;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -424,6 +430,7 @@ exports[`Card shows Card with non-default elevation 1`] = `
 
 exports[`Card shows Card with ripple feedback and no onClick 1`] = `
 .c0 {
+  contain: layout;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -463,6 +470,7 @@ exports[`Card shows Card with ripple feedback with onClick 1`] = `
 }
 
 .c0 {
+  contain: layout;
   cursor: pointer;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -511,6 +519,7 @@ exports[`Card shows Card with ripple feedback with onClick 1`] = `
 
 exports[`Card shows Card with simple feedback and no onClick 1`] = `
 .c0 {
+  contain: layout;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -539,6 +548,7 @@ exports[`Card shows Card with simple feedback and no onClick 1`] = `
 
 exports[`Card shows Card with simple feedback with onClick 1`] = `
 .c0 {
+  contain: layout;
   cursor: pointer;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;

--- a/src/components/Card/__tests__/__snapshots__/Card.test.tsx.snap
+++ b/src/components/Card/__tests__/__snapshots__/Card.test.tsx.snap
@@ -13,7 +13,6 @@ exports[`Card header bottom padding should be 0rem when body is present 1`] = `
 }
 
 .c0 {
-  contain: layout;
   cursor: pointer;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -27,6 +26,7 @@ exports[`Card header bottom padding should be 0rem when body is present 1`] = `
   border: 0px solid transparent;
   -webkit-transition: filter .5s, box-shadow .5s, border .3s, background-color .3s;
   transition: filter .5s, box-shadow .5s, border .3s, background-color .3s;
+  contain: layout;
   -webkit-filter: drop-shadow(0rem 0.06653090368236622rem 0.25rem rgba(39,47,78,0.4292196217912265));
   filter: drop-shadow(0rem 0.06653090368236622rem 0.25rem rgba(39,47,78,0.4292196217912265));
   background-color: #fff;
@@ -95,7 +95,6 @@ exports[`Card header bottom padding should be 0rem when footer is present 1`] = 
 }
 
 .c0 {
-  contain: layout;
   cursor: pointer;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -109,6 +108,7 @@ exports[`Card header bottom padding should be 0rem when footer is present 1`] = 
   border: 0px solid transparent;
   -webkit-transition: filter .5s, box-shadow .5s, border .3s, background-color .3s;
   transition: filter .5s, box-shadow .5s, border .3s, background-color .3s;
+  contain: layout;
   -webkit-filter: drop-shadow(0rem 0.06653090368236622rem 0.25rem rgba(39,47,78,0.4292196217912265));
   filter: drop-shadow(0rem 0.06653090368236622rem 0.25rem rgba(39,47,78,0.4292196217912265));
   background-color: #fff;
@@ -189,7 +189,6 @@ exports[`Card header bottom padding should be 1.5rem without body and footer 1`]
 }
 
 .c0 {
-  contain: layout;
   cursor: pointer;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -203,6 +202,7 @@ exports[`Card header bottom padding should be 1.5rem without body and footer 1`]
   border: 0px solid transparent;
   -webkit-transition: filter .5s, box-shadow .5s, border .3s, background-color .3s;
   transition: filter .5s, box-shadow .5s, border .3s, background-color .3s;
+  contain: layout;
   -webkit-filter: drop-shadow(0rem 0.06653090368236622rem 0.25rem rgba(39,47,78,0.4292196217912265));
   filter: drop-shadow(0rem 0.06653090368236622rem 0.25rem rgba(39,47,78,0.4292196217912265));
   background-color: #fff;
@@ -261,7 +261,6 @@ exports[`Card shows Card with default feedback 1`] = `
 }
 
 .c0 {
-  contain: layout;
   cursor: pointer;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -275,6 +274,7 @@ exports[`Card shows Card with default feedback 1`] = `
   border: 0px solid transparent;
   -webkit-transition: filter .5s, box-shadow .5s, border .3s, background-color .3s;
   transition: filter .5s, box-shadow .5s, border .3s, background-color .3s;
+  contain: layout;
   -webkit-filter: drop-shadow(0rem 0.06653090368236622rem 0.25rem rgba(39,47,78,0.4292196217912265));
   filter: drop-shadow(0rem 0.06653090368236622rem 0.25rem rgba(39,47,78,0.4292196217912265));
   background-color: #fff;
@@ -321,7 +321,6 @@ exports[`Card shows Card with default props 1`] = `
 }
 
 .c0 {
-  contain: layout;
   cursor: pointer;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -335,6 +334,7 @@ exports[`Card shows Card with default props 1`] = `
   border: 0px solid transparent;
   -webkit-transition: filter .5s, box-shadow .5s, border .3s, background-color .3s;
   transition: filter .5s, box-shadow .5s, border .3s, background-color .3s;
+  contain: layout;
   -webkit-filter: drop-shadow(0rem 0.06653090368236622rem 0.25rem rgba(39,47,78,0.4292196217912265));
   filter: drop-shadow(0rem 0.06653090368236622rem 0.25rem rgba(39,47,78,0.4292196217912265));
   background-color: #fff;
@@ -381,7 +381,6 @@ exports[`Card shows Card with non-default elevation 1`] = `
 }
 
 .c0 {
-  contain: layout;
   cursor: pointer;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -395,6 +394,7 @@ exports[`Card shows Card with non-default elevation 1`] = `
   border: 0px solid transparent;
   -webkit-transition: filter .5s, box-shadow .5s, border .3s, background-color .3s;
   transition: filter .5s, box-shadow .5s, border .3s, background-color .3s;
+  contain: layout;
   -webkit-filter: drop-shadow(0rem 0.07538939058881129rem 0.75rem rgba(39,47,78,0.3741399931653331));
   filter: drop-shadow(0rem 0.07538939058881129rem 0.75rem rgba(39,47,78,0.3741399931653331));
   background-color: #fff;
@@ -430,7 +430,6 @@ exports[`Card shows Card with non-default elevation 1`] = `
 
 exports[`Card shows Card with ripple feedback and no onClick 1`] = `
 .c0 {
-  contain: layout;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -443,6 +442,7 @@ exports[`Card shows Card with ripple feedback and no onClick 1`] = `
   border: 0px solid transparent;
   -webkit-transition: filter .5s, box-shadow .5s, border .3s, background-color .3s;
   transition: filter .5s, box-shadow .5s, border .3s, background-color .3s;
+  contain: layout;
   -webkit-filter: drop-shadow(0rem 0.06653090368236622rem 0.25rem rgba(39,47,78,0.4292196217912265));
   filter: drop-shadow(0rem 0.06653090368236622rem 0.25rem rgba(39,47,78,0.4292196217912265));
   background-color: #fff;
@@ -470,7 +470,6 @@ exports[`Card shows Card with ripple feedback with onClick 1`] = `
 }
 
 .c0 {
-  contain: layout;
   cursor: pointer;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -484,6 +483,7 @@ exports[`Card shows Card with ripple feedback with onClick 1`] = `
   border: 0px solid transparent;
   -webkit-transition: filter .5s, box-shadow .5s, border .3s, background-color .3s;
   transition: filter .5s, box-shadow .5s, border .3s, background-color .3s;
+  contain: layout;
   -webkit-filter: drop-shadow(0rem 0.06653090368236622rem 0.25rem rgba(39,47,78,0.4292196217912265));
   filter: drop-shadow(0rem 0.06653090368236622rem 0.25rem rgba(39,47,78,0.4292196217912265));
   background-color: #fff;
@@ -519,7 +519,6 @@ exports[`Card shows Card with ripple feedback with onClick 1`] = `
 
 exports[`Card shows Card with simple feedback and no onClick 1`] = `
 .c0 {
-  contain: layout;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -532,6 +531,7 @@ exports[`Card shows Card with simple feedback and no onClick 1`] = `
   border: 0px solid transparent;
   -webkit-transition: filter .5s, box-shadow .5s, border .3s, background-color .3s;
   transition: filter .5s, box-shadow .5s, border .3s, background-color .3s;
+  contain: layout;
   -webkit-filter: drop-shadow(0rem 0.06653090368236622rem 0.25rem rgba(39,47,78,0.4292196217912265));
   filter: drop-shadow(0rem 0.06653090368236622rem 0.25rem rgba(39,47,78,0.4292196217912265));
   background-color: #fff;
@@ -548,7 +548,6 @@ exports[`Card shows Card with simple feedback and no onClick 1`] = `
 
 exports[`Card shows Card with simple feedback with onClick 1`] = `
 .c0 {
-  contain: layout;
   cursor: pointer;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -562,6 +561,7 @@ exports[`Card shows Card with simple feedback with onClick 1`] = `
   border: 0px solid transparent;
   -webkit-transition: filter .5s, box-shadow .5s, border .3s, background-color .3s;
   transition: filter .5s, box-shadow .5s, border .3s, background-color .3s;
+  contain: layout;
   -webkit-filter: drop-shadow(0rem 0.06653090368236622rem 0.25rem rgba(39,47,78,0.4292196217912265));
   filter: drop-shadow(0rem 0.06653090368236622rem 0.25rem rgba(39,47,78,0.4292196217912265));
   background-color: #fff;

--- a/src/components/Dropdown/__tests__/__snapshots__/Dropdown.test.tsx.snap
+++ b/src/components/Dropdown/__tests__/__snapshots__/Dropdown.test.tsx.snap
@@ -23,6 +23,7 @@ exports[`Dropdown can focus dropdown and select option 1`] = `
   border-radius: 0.25em;
   -webkit-transition: background-color .2s, color .5s, outline .5s, filter .5s, box-shadow .5s;
   transition: background-color .2s, color .5s, outline .5s, filter .5s, box-shadow .5s;
+  contain: layout;
   outline: 0 none;
   border: 1px solid #252c35;
   cursor: pointer;
@@ -56,6 +57,7 @@ exports[`Dropdown can focus dropdown and select option 1`] = `
   width: fit-content;
   -webkit-transition: filter .5s,box-shadow .5s;
   transition: filter .5s,box-shadow .5s;
+  contain: layout;
   position: relative;
   z-index: 1;
 }
@@ -183,6 +185,7 @@ exports[`Dropdown closes options when clicking outside 1`] = `
   border-radius: 0.25em;
   -webkit-transition: background-color .2s, color .5s, outline .5s, filter .5s, box-shadow .5s;
   transition: background-color .2s, color .5s, outline .5s, filter .5s, box-shadow .5s;
+  contain: layout;
   outline: 0 none;
   border: 1px solid #252c35;
   cursor: pointer;
@@ -216,6 +219,7 @@ exports[`Dropdown closes options when clicking outside 1`] = `
   width: fit-content;
   -webkit-transition: filter .5s,box-shadow .5s;
   transition: filter .5s,box-shadow .5s;
+  contain: layout;
   position: relative;
   z-index: 7;
 }
@@ -425,6 +429,7 @@ exports[`Dropdown closes options when clicking outside 2`] = `
   border-radius: 0.25em;
   -webkit-transition: background-color .2s, color .5s, outline .5s, filter .5s, box-shadow .5s;
   transition: background-color .2s, color .5s, outline .5s, filter .5s, box-shadow .5s;
+  contain: layout;
   outline: 0 none;
   border: 1px solid #252c35;
   cursor: pointer;
@@ -458,6 +463,7 @@ exports[`Dropdown closes options when clicking outside 2`] = `
   width: fit-content;
   -webkit-transition: filter .5s,box-shadow .5s;
   transition: filter .5s,box-shadow .5s;
+  contain: layout;
   position: relative;
   z-index: 1;
 }
@@ -583,6 +589,7 @@ exports[`Dropdown deselects option when clicking on them twice when dropdown is 
   border-radius: 0.25em;
   -webkit-transition: background-color .2s, color .5s, outline .5s, filter .5s, box-shadow .5s;
   transition: background-color .2s, color .5s, outline .5s, filter .5s, box-shadow .5s;
+  contain: layout;
   outline: 0 none;
   border: 1px solid #252c35;
   cursor: pointer;
@@ -616,6 +623,7 @@ exports[`Dropdown deselects option when clicking on them twice when dropdown is 
   width: fit-content;
   -webkit-transition: filter .5s,box-shadow .5s;
   transition: filter .5s,box-shadow .5s;
+  contain: layout;
   position: relative;
   z-index: 1;
 }
@@ -742,6 +750,7 @@ exports[`Dropdown displays all options when focused 1`] = `
   border-radius: 0.25em;
   -webkit-transition: background-color .2s, color .5s, outline .5s, filter .5s, box-shadow .5s;
   transition: background-color .2s, color .5s, outline .5s, filter .5s, box-shadow .5s;
+  contain: layout;
   outline: 0 none;
   border: 1px solid #252c35;
   cursor: pointer;
@@ -775,6 +784,7 @@ exports[`Dropdown displays all options when focused 1`] = `
   width: fit-content;
   -webkit-transition: filter .5s,box-shadow .5s;
   transition: filter .5s,box-shadow .5s;
+  contain: layout;
   position: relative;
   z-index: 7;
 }
@@ -984,6 +994,7 @@ exports[`Dropdown displays placeholder value on initial render 1`] = `
   border-radius: 0.25em;
   -webkit-transition: background-color .2s, color .5s, outline .5s, filter .5s, box-shadow .5s;
   transition: background-color .2s, color .5s, outline .5s, filter .5s, box-shadow .5s;
+  contain: layout;
   outline: 0 none;
   border: 1px solid #252c35;
   cursor: pointer;
@@ -1017,6 +1028,7 @@ exports[`Dropdown displays placeholder value on initial render 1`] = `
   width: fit-content;
   -webkit-transition: filter .5s,box-shadow .5s;
   transition: filter .5s,box-shadow .5s;
+  contain: layout;
   position: relative;
   z-index: 1;
 }
@@ -1145,6 +1157,7 @@ exports[`Dropdown does not display options on initial render 1`] = `
   border-radius: 0.25em;
   -webkit-transition: background-color .2s, color .5s, outline .5s, filter .5s, box-shadow .5s;
   transition: background-color .2s, color .5s, outline .5s, filter .5s, box-shadow .5s;
+  contain: layout;
   outline: 0 none;
   border: 1px solid #252c35;
   cursor: pointer;
@@ -1178,6 +1191,7 @@ exports[`Dropdown does not display options on initial render 1`] = `
   width: fit-content;
   -webkit-transition: filter .5s,box-shadow .5s;
   transition: filter .5s,box-shadow .5s;
+  contain: layout;
   position: relative;
   z-index: 1;
 }
@@ -1304,6 +1318,7 @@ exports[`Dropdown renders a value when given a matching option id through props 
   border-radius: 0.25em;
   -webkit-transition: background-color .2s, color .5s, outline .5s, filter .5s, box-shadow .5s;
   transition: background-color .2s, color .5s, outline .5s, filter .5s, box-shadow .5s;
+  contain: layout;
   outline: 0 none;
   border: 1px solid #252c35;
   cursor: pointer;
@@ -1341,6 +1356,7 @@ exports[`Dropdown renders a value when given a matching option id through props 
   border-radius: 0.25em;
   -webkit-transition: background-color .2s, color .5s, outline .5s, filter .5s, box-shadow .5s;
   transition: background-color .2s, color .5s, outline .5s, filter .5s, box-shadow .5s;
+  contain: layout;
   outline: 0 none;
   border: 0 none;
   background-color: transparent;
@@ -1357,6 +1373,7 @@ exports[`Dropdown renders a value when given a matching option id through props 
   width: fit-content;
   -webkit-transition: filter .5s,box-shadow .5s;
   transition: filter .5s,box-shadow .5s;
+  contain: layout;
   position: relative;
   z-index: 1;
 }
@@ -1492,6 +1509,7 @@ exports[`Dropdown renders no value when given a value that doesn't match any opt
   border-radius: 0.25em;
   -webkit-transition: background-color .2s, color .5s, outline .5s, filter .5s, box-shadow .5s;
   transition: background-color .2s, color .5s, outline .5s, filter .5s, box-shadow .5s;
+  contain: layout;
   outline: 0 none;
   border: 1px solid #252c35;
   cursor: pointer;
@@ -1525,6 +1543,7 @@ exports[`Dropdown renders no value when given a value that doesn't match any opt
   width: fit-content;
   -webkit-transition: filter .5s,box-shadow .5s;
   transition: filter .5s,box-shadow .5s;
+  contain: layout;
   position: relative;
   z-index: 1;
 }
@@ -1643,6 +1662,7 @@ exports[`Dropdown renders one value when given two values but only one matches a
   border-radius: 0.25em;
   -webkit-transition: background-color .2s, color .5s, outline .5s, filter .5s, box-shadow .5s;
   transition: background-color .2s, color .5s, outline .5s, filter .5s, box-shadow .5s;
+  contain: layout;
   outline: 0 none;
   border: 1px solid #252c35;
   cursor: pointer;
@@ -1680,6 +1700,7 @@ exports[`Dropdown renders one value when given two values but only one matches a
   border-radius: 0.25em;
   -webkit-transition: background-color .2s, color .5s, outline .5s, filter .5s, box-shadow .5s;
   transition: background-color .2s, color .5s, outline .5s, filter .5s, box-shadow .5s;
+  contain: layout;
   outline: 0 none;
   border: 0 none;
   background-color: transparent;
@@ -1696,6 +1717,7 @@ exports[`Dropdown renders one value when given two values but only one matches a
   width: fit-content;
   -webkit-transition: filter .5s,box-shadow .5s;
   transition: filter .5s,box-shadow .5s;
+  contain: layout;
   position: relative;
   z-index: 1;
 }
@@ -1831,6 +1853,7 @@ exports[`Dropdown renders two values when given matching option ids through prop
   border-radius: 0.25em;
   -webkit-transition: background-color .2s, color .5s, outline .5s, filter .5s, box-shadow .5s;
   transition: background-color .2s, color .5s, outline .5s, filter .5s, box-shadow .5s;
+  contain: layout;
   outline: 0 none;
   border: 1px solid #252c35;
   cursor: pointer;
@@ -1868,6 +1891,7 @@ exports[`Dropdown renders two values when given matching option ids through prop
   border-radius: 0.25em;
   -webkit-transition: background-color .2s, color .5s, outline .5s, filter .5s, box-shadow .5s;
   transition: background-color .2s, color .5s, outline .5s, filter .5s, box-shadow .5s;
+  contain: layout;
   outline: 0 none;
   border: 0 none;
   background-color: transparent;
@@ -1884,6 +1908,7 @@ exports[`Dropdown renders two values when given matching option ids through prop
   width: fit-content;
   -webkit-transition: filter .5s,box-shadow .5s;
   transition: filter .5s,box-shadow .5s;
+  contain: layout;
   position: relative;
   z-index: 1;
 }
@@ -2027,6 +2052,7 @@ exports[`Dropdown renders two values when given matching option ids through prop
   border-radius: 0.25em;
   -webkit-transition: background-color .2s, color .5s, outline .5s, filter .5s, box-shadow .5s;
   transition: background-color .2s, color .5s, outline .5s, filter .5s, box-shadow .5s;
+  contain: layout;
   outline: 0 none;
   border: 1px solid #252c35;
   cursor: pointer;
@@ -2064,6 +2090,7 @@ exports[`Dropdown renders two values when given matching option ids through prop
   border-radius: 0.25em;
   -webkit-transition: background-color .2s, color .5s, outline .5s, filter .5s, box-shadow .5s;
   transition: background-color .2s, color .5s, outline .5s, filter .5s, box-shadow .5s;
+  contain: layout;
   outline: 0 none;
   border: 0 none;
   background-color: transparent;
@@ -2080,6 +2107,7 @@ exports[`Dropdown renders two values when given matching option ids through prop
   width: fit-content;
   -webkit-transition: filter .5s,box-shadow .5s;
   transition: filter .5s,box-shadow .5s;
+  contain: layout;
   position: relative;
   z-index: 1;
 }
@@ -2223,6 +2251,7 @@ exports[`Dropdown selects options from values prop 1`] = `
   border-radius: 0.25em;
   -webkit-transition: background-color .2s, color .5s, outline .5s, filter .5s, box-shadow .5s;
   transition: background-color .2s, color .5s, outline .5s, filter .5s, box-shadow .5s;
+  contain: layout;
   outline: 0 none;
   border: 1px solid #252c35;
   cursor: pointer;
@@ -2260,6 +2289,7 @@ exports[`Dropdown selects options from values prop 1`] = `
   border-radius: 0.25em;
   -webkit-transition: background-color .2s, color .5s, outline .5s, filter .5s, box-shadow .5s;
   transition: background-color .2s, color .5s, outline .5s, filter .5s, box-shadow .5s;
+  contain: layout;
   outline: 0 none;
   border: 0 none;
   background-color: transparent;
@@ -2276,6 +2306,7 @@ exports[`Dropdown selects options from values prop 1`] = `
   width: fit-content;
   -webkit-transition: filter .5s,box-shadow .5s;
   transition: filter .5s,box-shadow .5s;
+  contain: layout;
   position: relative;
   z-index: 1;
 }

--- a/src/components/Tag/__tests__/__snapshots__/Tag.test.tsx.snap
+++ b/src/components/Tag/__tests__/__snapshots__/Tag.test.tsx.snap
@@ -22,6 +22,7 @@ exports[`Tag keeps the container the same when switching between isLoading and n
   border-radius: 0.25em;
   -webkit-transition: background-color .2s, color .5s, outline .5s, filter .5s, box-shadow .5s;
   transition: background-color .2s, color .5s, outline .5s, filter .5s, box-shadow .5s;
+  contain: layout;
   outline: 0 none;
   border: 0 none;
   background-color: #7c8186;
@@ -62,6 +63,7 @@ exports[`Tag keeps the container the same when switching between isLoading and n
   border-radius: 0.25em;
   -webkit-transition: background-color .2s, color .5s, outline .5s, filter .5s, box-shadow .5s;
   transition: background-color .2s, color .5s, outline .5s, filter .5s, box-shadow .5s;
+  contain: layout;
   outline: 0 none;
   border: 0 none;
   background-color: #7c8186;
@@ -93,6 +95,7 @@ exports[`Tag shows LeftIconContainer when isProcessing 1`] = `
   border-radius: 0.25em;
   -webkit-transition: background-color .2s, color .5s, outline .5s, filter .5s, box-shadow .5s;
   transition: background-color .2s, color .5s, outline .5s, filter .5s, box-shadow .5s;
+  contain: layout;
   outline: 0 none;
   border: 0 none;
   background-color: #7c8186;
@@ -157,6 +160,7 @@ exports[`Tag shows Tag with fill variant 1`] = `
   border-radius: 0.25em;
   -webkit-transition: background-color .2s, color .5s, outline .5s, filter .5s, box-shadow .5s;
   transition: background-color .2s, color .5s, outline .5s, filter .5s, box-shadow .5s;
+  contain: layout;
   outline: 0 none;
   border: 0 none;
   background-color: #7c8186;
@@ -190,6 +194,7 @@ exports[`Tag shows Tag with non-default props variant and color 1`] = `
   border-radius: 0.25em;
   -webkit-transition: background-color .2s, color .5s, outline .5s, filter .5s, box-shadow .5s;
   transition: background-color .2s, color .5s, outline .5s, filter .5s, box-shadow .5s;
+  contain: layout;
   -webkit-filter: drop-shadow(0rem 0.07082177831667665rem 0.5rem rgba(39,47,78,0.39738511585523156));
   filter: drop-shadow(0rem 0.07082177831667665rem 0.5rem rgba(39,47,78,0.39738511585523156));
   outline: 0 none;
@@ -225,6 +230,7 @@ exports[`Tag shows Tag with outline variant 1`] = `
   border-radius: 0.25em;
   -webkit-transition: background-color .2s, color .5s, outline .5s, filter .5s, box-shadow .5s;
   transition: background-color .2s, color .5s, outline .5s, filter .5s, box-shadow .5s;
+  contain: layout;
   outline: 0 none;
   border: 1px solid #7c8186;
   background-color: transparent;
@@ -258,6 +264,7 @@ exports[`Tag shows Tag with text variant 1`] = `
   border-radius: 0.25em;
   -webkit-transition: background-color .2s, color .5s, outline .5s, filter .5s, box-shadow .5s;
   transition: background-color .2s, color .5s, outline .5s, filter .5s, box-shadow .5s;
+  contain: layout;
   outline: 0 none;
   border: 0 none;
   background-color: transparent;
@@ -291,6 +298,7 @@ exports[`Tag shows icons 1`] = `
   border-radius: 0.25em;
   -webkit-transition: background-color .2s, color .5s, outline .5s, filter .5s, box-shadow .5s;
   transition: background-color .2s, color .5s, outline .5s, filter .5s, box-shadow .5s;
+  contain: layout;
   outline: 0 none;
   border: 0 none;
   background-color: #7c8186;
@@ -359,6 +367,7 @@ exports[`Tag shows icons with type string 1`] = `
   border-radius: 0.25em;
   -webkit-transition: background-color .2s, color .5s, outline .5s, filter .5s, box-shadow .5s;
   transition: background-color .2s, color .5s, outline .5s, filter .5s, box-shadow .5s;
+  contain: layout;
   outline: 0 none;
   border: 0 none;
   background-color: #7c8186;
@@ -441,6 +450,7 @@ exports[`Tag shows loading text when provided 1`] = `
   border-radius: 0.25em;
   -webkit-transition: background-color .2s, color .5s, outline .5s, filter .5s, box-shadow .5s;
   transition: background-color .2s, color .5s, outline .5s, filter .5s, box-shadow .5s;
+  contain: layout;
   outline: 0 none;
   border: 0 none;
   background-color: #7c8186;

--- a/src/utils/styles.ts
+++ b/src/utils/styles.ts
@@ -52,15 +52,22 @@ export const calculateElevationValues = (elevation = 0) => {
  * @returns {string} The css style property and value
  */
 export const getShadowStyle = (elevation = 0, shadowColor: string) => {
+  const shadowStyle = 'contain: layout;';
   if (elevation === 0) {
-    return '';
+    return shadowStyle;
   }
+  
   const { red, green, blue } = parseToRgb(shadowColor);
   const { xOffset, yOffset, blur, opacity } = calculateElevationValues(elevation);
 
-  return elevation > 0
-    ? `filter: drop-shadow(${xOffset}rem ${yOffset}rem ${blur}rem rgba(${red}, ${green}, ${blue},${opacity}));`
-    : `box-shadow: inset ${xOffset}rem ${yOffset}rem ${blur}rem rgba(${red}, ${green}, ${blue},${opacity});`;
+  return `
+    ${shadowStyle}
+    ${
+      elevation > 0
+        ? `filter: drop-shadow(${xOffset}rem ${yOffset}rem ${blur}rem rgba(${red}, ${green}, ${blue},${opacity}));`
+        : `box-shadow: inset ${xOffset}rem ${yOffset}rem ${blur}rem rgba(${red}, ${green}, ${blue},${opacity});`
+    }
+  `;
 };
 
 /**


### PR DESCRIPTION
Fixes #233 by adding the `contain: layout;` style to the Card component's top-level container.

Since the `StyledFeedbackContainer` has an absolute position, the clickable element for the ripple interaction fills the screen when the `CardContainer` component is lacking a layout restriction. When the `elevation` prop > 0, the `box-shadow` on the Card container is replaced with a `filter: drop-shadow`, which provides this restriction. Adding a layout containment to the `CardContainer` component restricts this positioning with intention and does so for all elevation values.

Some helpful info:
- [CSS Positioning](https://www.w3schools.com/css/css_positioning.asp)
- [Why does applying a CSS-Filter on the parent break the child positioning?](https://stackoverflow.com/a/52937920)