### PR TITLE
fix(divider): adds the divider subcomponent to the module exports

### DIFF
--- a/src/components/Divider/Divider.tsx
+++ b/src/components/Divider/Divider.tsx
@@ -59,4 +59,5 @@ const Divider = ({
 );
 
 Divider.Container = DefaultDividerContainer;
+Divider.Divider = DefaultDivider;
 export default Divider;

--- a/src/components/Divider/Divider.tsx
+++ b/src/components/Divider/Divider.tsx
@@ -46,14 +46,8 @@ const Divider = ({
   height = '1px',
   containerRef,
   dividerRef,
-  ...rest
 }: DividerProps): JSX.Element => (
-  <StyledDividerContainer
-    data-test-id="hsui-Divider"
-    {...dividerContainerProps}
-    ref={containerRef}
-    {...rest}
-  >
+  <StyledDividerContainer data-test-id="hsui-Divider" {...dividerContainerProps} ref={containerRef}>
     <StyledDivider width={width} height={height} ref={dividerRef} {...dividerProps} />
   </StyledDividerContainer>
 );


### PR DESCRIPTION
Like the Container, the Divider should be exported to serve as a base for the Styled subcomponent
props

closes #280