### PR TITLE
build(coverage): stop generating coverage while testing during pre-push locally

### DIFF
--- a/.github/workflows/buildCheck.yml
+++ b/.github/workflows/buildCheck.yml
@@ -32,7 +32,7 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Test React
-        run: yarn run test
+        run: yarn run test-ci
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -123,7 +123,10 @@
     "webpack": "webpack --config webpack.config.js",
     "dts": "tsc --declaration --outDir dist/types/ --emitDeclarationOnly --declarationMap --allowJs false --checkJs false",
     "pre-push": "yarn run lint-ci && yarn run test && yarn run clean && yarn run webpack && yarn run dts",
-    "test": "rm -rf 'coverage/*' && jest --collectCoverage=true && jest-coverage-badges",
+    "test": "jest",
+    "test-ci": "rm -rf 'coverage/*' && jest --collectCoverage=true && jest-coverage-badges",
+    "update-tests": "jest -u",
+    "test-interactive": "jest --watch",
     "semver-dryrun": "npx semantic-release -d --debug",
     "semver-release": "npx semantic-release",
     "commit": "npx git-cz"


### PR DESCRIPTION
Coverage is now only generated in the GH action on buildCheck and stored in artifacts
