### PR TITLE
Stop collecting coverage by default for jest tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -15,7 +15,7 @@ module.exports = {
   clearMocks: true,
 
   // Indicates whether the coverage information should be collected while executing the test
-  collectCoverage: true,
+  collectCoverage: false,
 
   // An array of glob patterns indicating a set of files for which coverage information should be collected
   collectCoverageFrom: [
@@ -39,10 +39,10 @@ module.exports = {
   // A list of reporter names that Jest uses when writing coverage reports
   coverageReporters: [
     'json-summary',
-     'html',
-  //   'text',
-  //   'lcov',
-  //   'clover'
+    'html',
+    //   'text',
+    //   'lcov',
+    //   'clover'
   ],
 
   // An object that configures minimum threshold enforcement for coverage results
@@ -137,9 +137,7 @@ module.exports = {
   // setupFiles: [],
 
   // A list of paths to modules that run some code to configure or set up the testing framework before each test
-  setupFilesAfterEnv: [
-    './src/setupTests.ts'
-  ],
+  setupFilesAfterEnv: ['./src/setupTests.ts'],
 
   // A list of paths to snapshot serializer modules Jest should use for snapshot testing
   // snapshotSerializers: [],
@@ -159,10 +157,7 @@ module.exports = {
   // testLocationInResults: false,
 
   // The glob patterns Jest uses to detect test files
-  testMatch: [
-    '**/__tests__/**/*.[jt]s?(x)',
-    '**/?(*.)+(spec|test).[tj]s?(x)'
-  ],
+  testMatch: ['**/__tests__/**/*.[jt]s?(x)', '**/?(*.)+(spec|test).[tj]s?(x)'],
 
   // An array of regexp pattern strings that are matched against all test paths, matched tests are skipped
   // testPathIgnorePatterns: [

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "webpack": "webpack --config webpack.config.js",
     "dts": "tsc --declaration --outDir dist/types/ --emitDeclarationOnly --declarationMap --allowJs false --checkJs false",
     "pre-push": "yarn run lint-ci && yarn run test && yarn run clean && yarn run webpack && yarn run dts",
-    "test": "jest",
+    "test": "jest --collectCoverage=false",
     "test-ci": "rm -rf 'coverage/*' && jest --collectCoverage=true && jest-coverage-badges",
     "update-tests": "jest -u",
     "test-interactive": "jest --watch",


### PR DESCRIPTION
Coverage should only be collected (updated) during deployments in the GH Actions CI runner. This sets the default to false, and ensures only `test-ci` runs the coverage collection.