### PR TITLE
331 MainNavigation Component

### DIFF
--- a/src/components/MainNavigation/MainNavigation.stories.tsx
+++ b/src/components/MainNavigation/MainNavigation.stories.tsx
@@ -99,6 +99,7 @@ export const Default: Story<DefaultProps> = ({ ...args }: DefaultProps) => {
   React.useEffect(() => setHidden(args.hidden), [args.hidden]);
   const [expanded, setExpanded] = React.useState(args.bodyBelow);
   React.useEffect(() => setExpanded(args.bodyBelow), [args.bodyBelow]);
+  const [active, setActive] = React.useState(0);
 
   const getScrollSpeed = MainNavigation.getScrollSpeed(50);
 
@@ -126,7 +127,30 @@ export const Default: Story<DefaultProps> = ({ ...args }: DefaultProps) => {
             iconPrefix={getIconPath(Icons.mdiMagnify, 'grey')}
           />
         }
-        navButtons={args.navButtons}
+        navButtons={[
+          {
+            label: 'Link 1',
+            onClick: () => {
+              setActive(0);
+              action('click 1')();
+            },
+          },
+          {
+            label: 'Link 2',
+            onClick: () => {
+              setActive(1);
+              action('click 2')();
+            },
+          },
+          {
+            label: 'Link 3',
+            onClick: () => {
+              setActive(2);
+              action('click 3')();
+            },
+          },
+        ]}
+        activeButton={active}
         labelFontSize={args.labelFontSize}
         footer={
           <Button
@@ -159,26 +183,6 @@ Default.args = {
       Foundry UI
     </Text>
   ),
-  navButtons: [
-    {
-      label: 'Link 1',
-      onClick: () => {
-        action('click 1')();
-      },
-    },
-    {
-      label: 'Link 2',
-      onClick: () => {
-        action('click 2')();
-      },
-    },
-    {
-      label: 'Link 3',
-      onClick: () => {
-        action('click 3')();
-      },
-    },
-  ],
   labelFontSize: '.75rem',
   position: 'relative',
 };

--- a/src/components/MainNavigation/MainNavigation.stories.tsx
+++ b/src/components/MainNavigation/MainNavigation.stories.tsx
@@ -1,0 +1,185 @@
+import React from 'react';
+import { Story, Meta } from '@storybook/react';
+import { action } from '@storybook/addon-actions';
+import styled from 'styled-components';
+import Icon from '@mdi/react';
+import * as Icons from '@mdi/js';
+import colors from '../../enums/colors';
+// import { Main } from '../../htmlElements';
+import MainNavigation, { MainNavigationProps } from './MainNavigation';
+import Text from '../Text';
+import TextInput from '../TextInput';
+import Button from '../Button';
+
+type DefaultProps = MainNavigationProps;
+
+const App = styled.div`
+  outline: 1px grey solid;
+`;
+
+const HeaderText = styled(Text.Container)`
+  white-space: nowrap;
+`;
+
+const HamburgerButton = styled(Button.Container)`
+  height: 100%;
+  padding: 0.25rem;
+  margin-right: 1rem;
+  &:focus {
+    box-shadow: 0 0 0;
+  }
+`;
+
+const SearchBar = styled(TextInput.Container)`
+  width: 70%;
+  margin-left: auto;
+  margin-right: 1rem;
+  &:focus-within {
+    outline: none;
+    box-shadow: 0 0 5px 0.15rem ${colors.tertiary};
+  }
+`;
+
+const SearchInput = styled(TextInput.Input)`
+  &:focus {
+    box-shadow: 0 0 0;
+  }
+`;
+
+const lorem = `Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt
+ut labore et dolore magna aliqua. Porttitor massa id neque aliquam vestibulum morbi
+blandit cursus risus. Mi bibendum neque egestas congue quisque egestas diam. Pulvinar
+sapien et ligula ullamcorper. Ac turpis egestas integer eget aliquet nibh. Bibendum at
+varius vel pharetra vel turpis nunc eget. Interdum varius sit amet mattis vulputate enim
+nulla aliquet porttitor. Morbi tempus iaculis urna id volutpat. Auctor neque vitae tempus
+quam pellentesque. Tempor commodo ullamcorper a lacus vestibulum sed. Malesuada proin
+libero nunc consequat interdum varius. At volutpat diam ut venenatis tellus in metus
+vulputate eu. Quam adipiscing vitae proin sagittis nisl. Sagittis purus sit amet volutpat
+consequat. Magna fringilla urna porttitor rhoncus dolor. Vitae aliquet nec ullamcorper sit
+amet. Imperdiet dui accumsan sit amet nulla facilisi. Sapien faucibus et molestie ac
+feugiat sed lectus vestibulum. Sed tempus urna et pharetra pharetra. Ut placerat orci
+nulla pellentesque dignissim enim sit amet. Netus et malesuada fames ac turpis egestas
+integer. Bibendum est ultricies integer quis auctor elit sed. Et netus et malesuada fames
+ac turpis. Ultrices sagittis orci a scelerisque purus semper eget duis at. Non blandit
+massa enim nec dui nunc. Felis bibendum ut tristique et egestas quis. Volutpat ac
+tincidunt vitae semper. Adipiscing vitae proin sagittis nisl rhoncus mattis rhoncus urna.
+Donec enim diam vulputate ut pharetra sit amet aliquam. Quis enim lobortis scelerisque
+fermentum dui faucibus in ornare quam. Suspendisse sed nisi lacus sed viverra tellus in.
+Proin nibh nisl condimentum id venenatis. Duis tristique sollicitudin nibh sit amet
+commodo nulla. Sed cras ornare arcu dui. Consectetur adipiscing elit pellentesque habitant
+morbi tristique senectus et netus. Ut etiam sit amet nisl purus in mollis nunc. Aliquam id
+diam maecenas ultricies mi eget mauris pharetra et. Neque volutpat ac tincidunt vitae
+semper quis lectus. Amet nisl suscipit adipiscing bibendum. Ultrices sagittis orci a
+scelerisque purus. Et malesuada fames ac turpis egestas sed tempus. Euismod lacinia at
+quis risus sed vulputate. Egestas fringilla phasellus faucibus scelerisque eleifend donec.
+Nulla posuere sollicitudin aliquam ultrices sagittis orci a scelerisque purus. Nunc
+lobortis mattis aliquam faucibus purus in massa tempor. Euismod nisi porta lorem mollis
+aliquam. Varius vel pharetra vel turpis nunc eget lorem dolor sed. Tempus urna et pharetra
+pharetra massa massa ultricies mi quis. Aliquam faucibus purus in massa. Pellentesque sit
+amet porttitor eget dolor. Sit amet cursus sit amet dictum sit amet. Adipiscing elit ut
+aliquam purus sit. Velit ut tortor pretium viverra suspendisse. Aliquet nibh praesent
+tristique magna sit amet purus gravida. Risus pretium quam vulputate dignissim suspendisse
+in est ante. Nulla pharetra diam sit amet nisl suscipit adipiscing bibendum est. Tristique
+et egestas quis ipsum suspendisse ultrices gravida. Aliquam ut porttitor leo a diam. Quis
+hendrerit dolor magna eget est lorem. Sed tempus urna et pharetra pharetra massa massa
+ultricies mi. Venenatis urna cursus eget nunc scelerisque viverra mauris. Sed egestas
+egestas fringilla phasellus faucibus scelerisque eleifend. Venenatis tellus in metus
+vulputate eu. Parturient montes nascetur ridiculus mus. Id diam vel quam elementum
+pulvinar etiam. Magna etiam tempor orci eu.`;
+
+const getIconPath = (path: string, color: string) =>
+  path ? <Icon color={color} size="1rem" path={path} /> : undefined;
+
+export const Default: Story<DefaultProps> = ({ ...args }: DefaultProps) => {
+  const [hidden, setHidden] = React.useState(args.hidden);
+  React.useEffect(() => setHidden(hidden), [hidden]);
+
+  const getScrollSpeed = MainNavigation.getScrollSpeed(50);
+
+  return (
+    <App>
+      <MainNavigation
+        hidden={hidden}
+        hiddenBelowY={args.hiddenBelowY}
+        onScroll={() => {
+          action(`Scrolled with speed: ${Math.abs(getScrollSpeed())}`)();
+        }}
+        position={args.position}
+        location={args.location}
+        color={args.color}
+        height={args.height}
+        header={args.header}
+        body={args.body}
+        navButtons={args.navButtons}
+        labelFontSize={args.labelFontSize}
+        footer={args.footer}
+      />
+      <body>
+        <h2>
+          <Text>Lorem ipsum</Text>
+        </h2>
+        <Text>{lorem.repeat(10)}</Text>
+      </body>
+    </App>
+  );
+};
+Default.args = {
+  hidden: false,
+  hiddenBelowY: 100,
+  color: colors.primaryDark,
+  height: '3rem',
+  header: (
+    <Text StyledContainer={HeaderText} color="#fff">
+      Foundry UI
+    </Text>
+  ),
+  body: (
+    <TextInput
+      placeholder="Search Bar"
+      StyledContainer={SearchBar}
+      StyledInput={SearchInput}
+      iconPrefix={getIconPath(Icons.mdiMagnify, 'grey')}
+    />
+  ),
+  navButtons: [
+    {
+      label: 'Link 1',
+      onClick: () => {
+        action('click 1')();
+      },
+    },
+    {
+      label: 'Link 2',
+      onClick: () => {
+        action('click 2')();
+      },
+    },
+    {
+      label: 'Link 3',
+      onClick: () => {
+        action('click 3')();
+      },
+    },
+  ],
+  labelFontSize: '.75rem',
+  footer: (
+    <Button color="#0000" StyledContainer={HamburgerButton}>
+      {getIconPath(Icons.mdiMenu, 'white')}
+    </Button>
+  ),
+  position: 'relative',
+};
+
+export default {
+  title: 'MainNavigation',
+  component: MainNavigation,
+  argTypes: {
+    position: {
+      options: ['relative', 'sticky', 'fixed', 'static'],
+      control: {
+        type: 'select',
+      },
+    },
+  },
+  parameters: {},
+} as Meta;

--- a/src/components/MainNavigation/MainNavigation.stories.tsx
+++ b/src/components/MainNavigation/MainNavigation.stories.tsx
@@ -96,9 +96,9 @@ const getIconPath = (path: string, color: string) =>
 
 export const Default: Story<DefaultProps> = ({ ...args }: DefaultProps) => {
   const [hidden, setHidden] = React.useState(args.hidden);
-  React.useEffect(() => setHidden(hidden), [hidden]);
+  React.useEffect(() => setHidden(args.hidden), [args.hidden]);
   const [expanded, setExpanded] = React.useState(args.bodyBelow);
-  React.useEffect(() => setExpanded(expanded), [expanded]);
+  React.useEffect(() => setExpanded(args.bodyBelow), [args.bodyBelow]);
 
   const getScrollSpeed = MainNavigation.getScrollSpeed(50);
 

--- a/src/components/MainNavigation/MainNavigation.stories.tsx
+++ b/src/components/MainNavigation/MainNavigation.stories.tsx
@@ -23,7 +23,7 @@ const HeaderText = styled(Text.Container)`
 
 const HamburgerButton = styled(Button.Container)`
   height: 100%;
-  padding: 0.25rem;
+  padding: 0.5rem;
   margin-right: 1rem;
   &:focus {
     box-shadow: 0 0 0;
@@ -31,13 +31,17 @@ const HamburgerButton = styled(Button.Container)`
 `;
 
 const SearchBar = styled(TextInput.Container)`
-  width: 70%;
-  margin-left: auto;
-  margin-right: 1rem;
-  &:focus-within {
-    outline: none;
-    box-shadow: 0 0 5px 0.15rem ${colors.tertiary};
-  }
+  ${({ expanded }: { expanded: boolean }) => `
+    width: ${expanded ? '99%' : '80%'};
+    margin-left: auto;
+    margin-right: ${expanded ? 'auto' : '1rem'};
+    margin-top: 0.25rem;
+    margin-bottom: 0.25rem;
+    &:focus-within {
+      outline: none;
+      box-shadow: 0 0 5px 0.15rem ${colors.tertiary};
+    }
+  `}
 `;
 
 const SearchInput = styled(TextInput.Input)`
@@ -93,6 +97,8 @@ const getIconPath = (path: string, color: string) =>
 export const Default: Story<DefaultProps> = ({ ...args }: DefaultProps) => {
   const [hidden, setHidden] = React.useState(args.hidden);
   React.useEffect(() => setHidden(hidden), [hidden]);
+  const [expanded, setExpanded] = React.useState(args.bodyBelow);
+  React.useEffect(() => setExpanded(expanded), [expanded]);
 
   const getScrollSpeed = MainNavigation.getScrollSpeed(50);
 
@@ -100,7 +106,9 @@ export const Default: Story<DefaultProps> = ({ ...args }: DefaultProps) => {
     <App>
       <MainNavigation
         hidden={hidden}
+        hideBody={args.hideBody && !expanded}
         hiddenBelowY={args.hiddenBelowY}
+        bodyBelow={expanded}
         onScroll={() => {
           action(`Scrolled with speed: ${Math.abs(getScrollSpeed())}`)();
         }}
@@ -109,10 +117,26 @@ export const Default: Story<DefaultProps> = ({ ...args }: DefaultProps) => {
         color={args.color}
         height={args.height}
         header={args.header}
-        body={args.body}
+        body={
+          <TextInput
+            placeholder="Search Bar"
+            StyledContainer={SearchBar}
+            containerProps={{ expanded }}
+            StyledInput={SearchInput}
+            iconPrefix={getIconPath(Icons.mdiMagnify, 'grey')}
+          />
+        }
         navButtons={args.navButtons}
         labelFontSize={args.labelFontSize}
-        footer={args.footer}
+        footer={
+          <Button
+            color="#0000"
+            StyledContainer={HamburgerButton}
+            onClick={() => setExpanded(!expanded)}
+          >
+            {getIconPath(Icons.mdiMenu, 'white')}
+          </Button>
+        }
       />
       <body>
         <h2>
@@ -126,20 +150,14 @@ export const Default: Story<DefaultProps> = ({ ...args }: DefaultProps) => {
 Default.args = {
   hidden: false,
   hiddenBelowY: 100,
+  hideBody: false,
+  bodyBelow: false,
   color: colors.primaryDark,
-  height: '3rem',
+  height: 'fit-content',
   header: (
     <Text StyledContainer={HeaderText} color="#fff">
       Foundry UI
     </Text>
-  ),
-  body: (
-    <TextInput
-      placeholder="Search Bar"
-      StyledContainer={SearchBar}
-      StyledInput={SearchInput}
-      iconPrefix={getIconPath(Icons.mdiMagnify, 'grey')}
-    />
   ),
   navButtons: [
     {
@@ -162,11 +180,6 @@ Default.args = {
     },
   ],
   labelFontSize: '.75rem',
-  footer: (
-    <Button color="#0000" StyledContainer={HamburgerButton}>
-      {getIconPath(Icons.mdiMenu, 'white')}
-    </Button>
-  ),
   position: 'relative',
 };
 

--- a/src/components/MainNavigation/MainNavigation.tsx
+++ b/src/components/MainNavigation/MainNavigation.tsx
@@ -154,16 +154,24 @@ export interface MainNavigationProps {
 
   header?: ReactNode;
   body?: ReactNode;
+  // navButtons are a list of links as buttons with onClicks that are included in the body section before the body object
   navButtons?: NavButton[];
   labelFontSize?: string;
   footer?: ReactNode;
 
   hidden?: boolean;
   disabled?: boolean;
+
+  // removes body, good for mobile to hide unless the body is expanded below
   hideBody?: boolean;
+  // puts body below the header and footer sections
   bodyBelow?: boolean;
+  // enables automatically hiding the navbar below a certain scroll position, only usable when window.onscroll
+  // is available. Otherwise use the hidden prop and your own function to detect position
   hiddenBelowY?: number;
+  // function to call when window.onscroll is used
   onScroll?: () => void;
+
   HideAnimationProps?: HideAnimationPropType;
   hideAnimation?: (value: HideAnimationPropType) => void;
   // set CSS position type ie `relative`, `absolute`, `static`, etc.
@@ -202,7 +210,6 @@ const MainNavigation = ({
   disabled = false,
   hideBody = false,
   bodyBelow = false,
-  // auto hiding below Y uses window.onscroll by default, for server-side rendering use your own onscroll to set the hidden argument
   hiddenBelowY,
   onScroll,
   HideAnimationProps,

--- a/src/components/MainNavigation/MainNavigation.tsx
+++ b/src/components/MainNavigation/MainNavigation.tsx
@@ -146,6 +146,7 @@ export interface MainNavigationProps {
   StyledHeader?: StyledSubcomponentType;
   StyledBody?: StyledSubcomponentType;
   StyledFooter?: StyledSubcomponentType;
+  StyledNavButtonContainer?: StyledSubcomponentType;
 
   containerProps?: SubcomponentPropsType;
   headerProps?: SubcomponentPropsType;
@@ -195,6 +196,7 @@ const MainNavigation = ({
   StyledHeader = Header,
   StyledBody = Body,
   StyledFooter = Footer,
+  StyledNavButtonContainer = NavButtonContainer,
 
   containerProps = {},
   headerProps = {},
@@ -262,7 +264,7 @@ const MainNavigation = ({
               key={navButton.label}
               onClick={navButton.onClick}
               color={getNavColor(index)}
-              StyledContainer={NavButtonContainer}
+              StyledContainer={StyledNavButtonContainer}
               containerProps={{ bodyBelow, ...navButtonProps[index] }}
             >
               <Text

--- a/src/components/MainNavigation/MainNavigation.tsx
+++ b/src/components/MainNavigation/MainNavigation.tsx
@@ -292,37 +292,20 @@ const MainNavigation = ({
       disabled={disabled}
       {...containerProps}
     >
-      {bodyBelow ? (
-        <>
-          <NavFlex>
-            {header && (
-              <StyledHeader ref={headerRef} {...headerProps}>
-                {header}
-              </StyledHeader>
-            )}
-            {footer && (
-              <StyledFooter ref={footerRef} {...footerProps}>
-                {footer}
-              </StyledFooter>
-            )}
-          </NavFlex>
-          <FinalBody />
-        </>
-      ) : (
-        <NavFlex>
-          {header && (
-            <StyledHeader ref={headerRef} {...headerProps}>
-              {header}
-            </StyledHeader>
-          )}
-          <FinalBody />
-          {footer && (
-            <StyledFooter ref={footerRef} {...footerProps}>
-              {footer}
-            </StyledFooter>
-          )}
-        </NavFlex>
-      )}
+      <NavFlex>
+        {header && (
+          <StyledHeader ref={headerRef} {...headerProps}>
+            {header}
+          </StyledHeader>
+        )}
+        {!bodyBelow && <FinalBody />}
+        {footer && (
+          <StyledFooter ref={footerRef} {...footerProps}>
+            {footer}
+          </StyledFooter>
+        )}
+      </NavFlex>
+      {bodyBelow && <FinalBody />}
     </StyledContainer>
   );
 };

--- a/src/components/MainNavigation/MainNavigation.tsx
+++ b/src/components/MainNavigation/MainNavigation.tsx
@@ -1,5 +1,6 @@
 import React, { ReactNode } from 'react';
 import styled from 'styled-components';
+import { darken } from 'polished';
 import { getFontColorFromVariant, disabledStyles } from '../../utils/color';
 import { Div } from '../../htmlElements';
 import { StyledSubcomponentType, SubcomponentPropsType } from '../commonTypes';
@@ -82,15 +83,21 @@ export const Body = styled(NavSection)`
 `;
 
 export const NavButtonContainer = styled(Button.Container)`
-  width: fit-content;
-  padding: 0.25rem 0rem 0.25rem 1rem;
-  height: 100%;
+  ${({ bodyBelow }: { bodyBelow: boolean }) => `
+  align-self: stretch;
+  width: ${bodyBelow ? '100%' : 'fit-content'};
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
   border-radius: 0 0 0 0;
-  &:hover {
-    text-decoration: underline;
-  }
   &:focus {
     box-shadow: 0 0 0;
+  }
+  `}
+`;
+
+export const NavText = styled(Text.Container)`
+  &:hover {
+    text-decoration: underline;
   }
 `;
 
@@ -157,6 +164,7 @@ export interface MainNavigationProps {
   // navButtons are a list of links as buttons with onClicks that are included in the body section before the body object
   navButtons?: NavButton[];
   labelFontSize?: string;
+  activeButton?: number;
   footer?: ReactNode;
 
   hidden?: boolean;
@@ -203,6 +211,7 @@ const MainNavigation = ({
   header,
   body,
   navButtons,
+  activeButton,
   labelFontSize = '1rem',
   footer,
 
@@ -234,6 +243,44 @@ const MainNavigation = ({
     collapsed: hidden || isHidden,
   };
 
+  const getNavColor = (index: number) => {
+    if (activeButton === index) {
+      return backgroundColor !== 'transparent'
+        ? darken(0.08, backgroundColor)
+        : 'rgba(0, 0, 0, 0.08)';
+    }
+    return backgroundColor;
+  };
+
+  const FinalBody = () => {
+    return !hideBody ? (
+      <StyledBody ref={bodyRef} bodyBelow={bodyBelow} {...bodyProps}>
+        {navButtons &&
+          navButtons.map((navButton, index) => (
+            <Button
+              containerRef={navButtonRefs[index]}
+              key={navButton.label}
+              onClick={navButton.onClick}
+              color={getNavColor(index)}
+              StyledContainer={NavButtonContainer}
+              containerProps={{ bodyBelow, ...navButtonProps[index] }}
+            >
+              <Text
+                color={getFontColorFromVariant(variants.fill, backgroundColor)}
+                size={labelFontSize}
+                StyledContainer={NavText}
+              >
+                {navButton.label}
+              </Text>
+            </Button>
+          ))}
+        {body && body}
+      </StyledBody>
+    ) : (
+      <></>
+    );
+  };
+
   return (
     <StyledContainer
       ref={containerRef}
@@ -259,31 +306,7 @@ const MainNavigation = ({
               </StyledFooter>
             )}
           </NavFlex>
-          {!hideBody ? (
-            <StyledBody ref={bodyRef} bodyBelow={bodyBelow} {...bodyProps}>
-              {navButtons &&
-                navButtons.map((navButton, index) => (
-                  <Button
-                    containerRef={navButtonRefs[index]}
-                    key={navButton.label}
-                    onClick={navButton.onClick}
-                    color="#0000"
-                    StyledContainer={NavButtonContainer}
-                    containerProps={{ ...navButtonProps[index] }}
-                  >
-                    <Text
-                      color={getFontColorFromVariant(variants.fill, backgroundColor)}
-                      size={labelFontSize}
-                    >
-                      {navButton.label}
-                    </Text>
-                  </Button>
-                ))}
-              {body && body}
-            </StyledBody>
-          ) : (
-            ''
-          )}
+          <FinalBody />
         </>
       ) : (
         <NavFlex>
@@ -292,31 +315,7 @@ const MainNavigation = ({
               {header}
             </StyledHeader>
           )}
-          {!hideBody ? (
-            <StyledBody ref={bodyRef} bodyBelow={bodyBelow} {...bodyProps}>
-              {navButtons &&
-                navButtons.map((navButton, index) => (
-                  <Button
-                    containerRef={navButtonRefs[index]}
-                    key={navButton.label}
-                    onClick={navButton.onClick}
-                    color="#0000"
-                    StyledContainer={NavButtonContainer}
-                    containerProps={{ ...navButtonProps[index] }}
-                  >
-                    <Text
-                      color={getFontColorFromVariant(variants.fill, backgroundColor)}
-                      size={labelFontSize}
-                    >
-                      {navButton.label}
-                    </Text>
-                  </Button>
-                ))}
-              {body && body}
-            </StyledBody>
-          ) : (
-            ''
-          )}
+          <FinalBody />
           {footer && (
             <StyledFooter ref={footerRef} {...footerProps}>
               {footer}

--- a/src/components/MainNavigation/MainNavigation.tsx
+++ b/src/components/MainNavigation/MainNavigation.tsx
@@ -55,19 +55,24 @@ const NavFlex = styled(Div)`
   height: 100%;
   width: 100%;
   display: flex;
-  flex-direction: row;
   align-items: center;
   align-content: stretch;
   padding-left: 1rem;
 `;
 
 export const NavSection = styled(Div)`
+  ${({ bodyBelow }: { bodyBelow: boolean }) => `
+    flex-direction: ${bodyBelow ? 'column' : 'row'};
+    align-items: ${bodyBelow ? 'flex-start' : 'center'};
+  `}
   display: flex;
   height: 100%;
-  align-items: center;
 `;
 
 export const Header = styled(NavSection)`
+  ${({ bodyBelow }: { bodyBelow: boolean }) => `
+    align-self: ${bodyBelow ? 'flex-start' : 'center'};
+  `}
   margin-right: 1rem;
   width: fit-content;
 `;
@@ -78,7 +83,7 @@ export const Body = styled(NavSection)`
 
 export const NavButtonContainer = styled(Button.Container)`
   width: fit-content;
-  padding: 0.25rem 0.5rem 0.25rem 0.5rem;
+  padding: 0.25rem 0rem 0.25rem 1rem;
   height: 100%;
   border-radius: 0 0 0 0;
   &:hover {
@@ -155,6 +160,8 @@ export interface MainNavigationProps {
 
   hidden?: boolean;
   disabled?: boolean;
+  hideBody?: boolean;
+  bodyBelow?: boolean;
   hiddenBelowY?: number;
   onScroll?: () => void;
   HideAnimationProps?: HideAnimationPropType;
@@ -193,6 +200,8 @@ const MainNavigation = ({
 
   hidden = false,
   disabled = false,
+  hideBody = false,
+  bodyBelow = false,
   // auto hiding below Y uses window.onscroll by default, for server-side rendering use your own onscroll to set the hidden argument
   hiddenBelowY,
   onScroll,
@@ -200,7 +209,7 @@ const MainNavigation = ({
   hideAnimation = defaultHideAnimation,
   position = 'relative',
   location = '',
-  height = '3rem',
+  height = 'fit-content',
   color,
 }: MainNavigationProps): JSX.Element => {
   const { colors } = useTheme();
@@ -229,39 +238,85 @@ const MainNavigation = ({
       disabled={disabled}
       {...containerProps}
     >
-      <NavFlex>
-        {header && (
-          <StyledHeader ref={headerRef} {...headerProps}>
-            {header}
-          </StyledHeader>
-        )}
-        <StyledBody ref={bodyRef} {...bodyProps}>
-          {navButtons &&
-            navButtons.map((navButton, index) => (
-              <Button
-                containerRef={navButtonRefs[index]}
-                key={navButton.label}
-                onClick={navButton.onClick}
-                color="#0000"
-                StyledContainer={NavButtonContainer}
-                containerProps={{ ...navButtonProps[index] }}
-              >
-                <Text
-                  color={getFontColorFromVariant(variants.fill, backgroundColor)}
-                  size={labelFontSize}
-                >
-                  {navButton.label}
-                </Text>
-              </Button>
-            ))}
-          {body && body}
-        </StyledBody>
-        {footer && (
-          <StyledFooter ref={footerRef} {...footerProps}>
-            {footer}
-          </StyledFooter>
-        )}
-      </NavFlex>
+      {bodyBelow ? (
+        <>
+          <NavFlex>
+            {header && (
+              <StyledHeader ref={headerRef} {...headerProps}>
+                {header}
+              </StyledHeader>
+            )}
+            {footer && (
+              <StyledFooter ref={footerRef} {...footerProps}>
+                {footer}
+              </StyledFooter>
+            )}
+          </NavFlex>
+          {!hideBody ? (
+            <StyledBody ref={bodyRef} bodyBelow={bodyBelow} {...bodyProps}>
+              {navButtons &&
+                navButtons.map((navButton, index) => (
+                  <Button
+                    containerRef={navButtonRefs[index]}
+                    key={navButton.label}
+                    onClick={navButton.onClick}
+                    color="#0000"
+                    StyledContainer={NavButtonContainer}
+                    containerProps={{ ...navButtonProps[index] }}
+                  >
+                    <Text
+                      color={getFontColorFromVariant(variants.fill, backgroundColor)}
+                      size={labelFontSize}
+                    >
+                      {navButton.label}
+                    </Text>
+                  </Button>
+                ))}
+              {body && body}
+            </StyledBody>
+          ) : (
+            ''
+          )}
+        </>
+      ) : (
+        <NavFlex>
+          {header && (
+            <StyledHeader ref={headerRef} {...headerProps}>
+              {header}
+            </StyledHeader>
+          )}
+          {!hideBody ? (
+            <StyledBody ref={bodyRef} bodyBelow={bodyBelow} {...bodyProps}>
+              {navButtons &&
+                navButtons.map((navButton, index) => (
+                  <Button
+                    containerRef={navButtonRefs[index]}
+                    key={navButton.label}
+                    onClick={navButton.onClick}
+                    color="#0000"
+                    StyledContainer={NavButtonContainer}
+                    containerProps={{ ...navButtonProps[index] }}
+                  >
+                    <Text
+                      color={getFontColorFromVariant(variants.fill, backgroundColor)}
+                      size={labelFontSize}
+                    >
+                      {navButton.label}
+                    </Text>
+                  </Button>
+                ))}
+              {body && body}
+            </StyledBody>
+          ) : (
+            ''
+          )}
+          {footer && (
+            <StyledFooter ref={footerRef} {...footerProps}>
+              {footer}
+            </StyledFooter>
+          )}
+        </NavFlex>
+      )}
     </StyledContainer>
   );
 };

--- a/src/components/MainNavigation/MainNavigation.tsx
+++ b/src/components/MainNavigation/MainNavigation.tsx
@@ -1,0 +1,278 @@
+import React, { ReactNode } from 'react';
+import styled from 'styled-components';
+import { getFontColorFromVariant, disabledStyles } from '../../utils/color';
+import { Div } from '../../htmlElements';
+import { StyledSubcomponentType, SubcomponentPropsType } from '../commonTypes';
+import { useTheme } from '../../context';
+import Button from '../Button';
+import Text from '../Text';
+import variants from '../../enums/variants';
+
+export type HideAnimationPropType = {
+  length?: number;
+  origin?: string;
+  collapsed: boolean;
+};
+
+export const defaultHideAnimation = ({
+  length = 0.1,
+  origin = 'top',
+  collapsed,
+}: HideAnimationPropType) => `
+    transform: ${collapsed ? 'scaleY(0)' : 'scaleY(1)'};
+    transform-origin: ${origin};
+    transition: transform ${length}s cubic-bezier(0, .7, .9, 1);;    
+`;
+
+export const Container = styled(Div)`
+  ${({
+    color,
+    height,
+    position,
+    location,
+    animation,
+    disabled,
+  }: {
+    color: string;
+    height: string;
+    position: string;
+    location: string;
+    animation: () => void;
+    disabled: boolean;
+  }) => `
+    position: ${position};
+    ${location}
+    background-color: ${color};
+    color: ${getFontColorFromVariant(variants.fill, color)};
+    height: ${height};
+    width: 100%;
+    ${animation}    
+    ${disabled ? disabledStyles() : ''}
+  `}
+`;
+
+const NavFlex = styled(Div)`
+  height: 100%;
+  width: 100%;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  align-content: stretch;
+  padding-left: 1rem;
+`;
+
+export const NavSection = styled(Div)`
+  display: flex;
+  height: 100%;
+  align-items: center;
+`;
+
+export const Header = styled(NavSection)`
+  margin-right: 1rem;
+  width: fit-content;
+`;
+
+export const Body = styled(NavSection)`
+  width: 100%;
+`;
+
+export const NavButtonContainer = styled(Button.Container)`
+  width: fit-content;
+  padding: 0.25rem 0.5rem 0.25rem 0.5rem;
+  height: 100%;
+  border-radius: 0 0 0 0;
+  &:hover {
+    text-decoration: underline;
+  }
+  &:focus {
+    box-shadow: 0 0 0;
+  }
+`;
+
+export const Footer = styled(NavSection)`
+  margin-left: auto;
+`;
+
+export type NavButton = {
+  label: string;
+  onClick: () => void;
+};
+
+const getGetScrollSpeed = (scrollSpeed = 50) => {
+  let lastPos: number | null;
+  let newPos: number | null;
+  let timer: NodeJS.Timeout;
+  let delta: number;
+  const delay = scrollSpeed; // in "ms" (higher means lower fidelity )
+
+  function clear() {
+    lastPos = null;
+    delta = 0;
+  }
+
+  clear();
+
+  return () => {
+    newPos = window.scrollY;
+    if (lastPos != null) {
+      delta = newPos - lastPos;
+    }
+    lastPos = newPos;
+    clearTimeout(timer);
+    timer = setTimeout(clear, delay);
+    return delta;
+  };
+};
+
+export const getScrollPosition = (): number => {
+  const doc = document.documentElement;
+  return (window.pageYOffset || doc.scrollTop) - (doc.clientTop || 0);
+};
+
+export interface MainNavigationProps {
+  StyledContainer?: StyledSubcomponentType;
+  StyledHeader?: StyledSubcomponentType;
+  StyledBody?: StyledSubcomponentType;
+  StyledFooter?: StyledSubcomponentType;
+
+  containerProps?: SubcomponentPropsType;
+  headerProps?: SubcomponentPropsType;
+  bodyProps?: SubcomponentPropsType;
+  footerProps?: SubcomponentPropsType;
+  navButtonProps?: SubcomponentPropsType[];
+
+  containerRef?: React.RefObject<HTMLDivElement>;
+  headerRef?: React.RefObject<HTMLDivElement>;
+  bodyRef?: React.RefObject<HTMLDivElement>;
+  footerRef?: React.RefObject<HTMLDivElement>;
+  navButtonRefs?: React.RefObject<HTMLButtonElement>[];
+
+  header?: ReactNode;
+  body?: ReactNode;
+  navButtons?: NavButton[];
+  labelFontSize?: string;
+  footer?: ReactNode;
+
+  hidden?: boolean;
+  disabled?: boolean;
+  hiddenBelowY?: number;
+  onScroll?: () => void;
+  HideAnimationProps?: HideAnimationPropType;
+  hideAnimation?: (value: HideAnimationPropType) => void;
+  // set CSS position type ie `relative`, `absolute`, `static`, etc.
+  position?: string;
+  // set CSS location directly like `top: 10px; left: 10px;`
+  location?: string;
+  height?: string;
+  color?: string;
+}
+
+const MainNavigation = ({
+  StyledContainer = Container,
+  StyledHeader = Header,
+  StyledBody = Body,
+  StyledFooter = Footer,
+
+  containerProps = {},
+  headerProps = {},
+  bodyProps = {},
+  footerProps = {},
+  navButtonProps = [{}],
+
+  containerRef,
+  headerRef,
+  bodyRef,
+  footerRef,
+  navButtonRefs = [],
+
+  header,
+  body,
+  navButtons,
+  labelFontSize = '1rem',
+  footer,
+
+  hidden = false,
+  disabled = false,
+  // auto hiding below Y uses window.onscroll by default, for server-side rendering use your own onscroll to set the hidden argument
+  hiddenBelowY,
+  onScroll,
+  HideAnimationProps,
+  hideAnimation = defaultHideAnimation,
+  position = 'relative',
+  location = '',
+  height = '3rem',
+  color,
+}: MainNavigationProps): JSX.Element => {
+  const { colors } = useTheme();
+  const backgroundColor = color || colors.primaryDark;
+  const [isHidden, setIsHidden] = React.useState(false);
+  if (typeof hiddenBelowY !== 'undefined') {
+    window.onscroll = () => {
+      if (onScroll) {
+        onScroll();
+      }
+      setIsHidden(getScrollPosition() > hiddenBelowY);
+    };
+  }
+  const animationProps = HideAnimationProps || {
+    collapsed: hidden || isHidden,
+  };
+
+  return (
+    <StyledContainer
+      ref={containerRef}
+      height={height}
+      color={backgroundColor}
+      position={position}
+      location={location}
+      animation={hideAnimation(animationProps)}
+      disabled={disabled}
+      {...containerProps}
+    >
+      <NavFlex>
+        {header && (
+          <StyledHeader ref={headerRef} {...headerProps}>
+            {header}
+          </StyledHeader>
+        )}
+        <StyledBody ref={bodyRef} {...bodyProps}>
+          {navButtons &&
+            navButtons.map((navButton, index) => (
+              <Button
+                containerRef={navButtonRefs[index]}
+                key={navButton.label}
+                onClick={navButton.onClick}
+                color="#0000"
+                StyledContainer={NavButtonContainer}
+                containerProps={{ ...navButtonProps[index] }}
+              >
+                <Text
+                  color={getFontColorFromVariant(variants.fill, backgroundColor)}
+                  size={labelFontSize}
+                >
+                  {navButton.label}
+                </Text>
+              </Button>
+            ))}
+          {body && body}
+        </StyledBody>
+        {footer && (
+          <StyledFooter ref={footerRef} {...footerProps}>
+            {footer}
+          </StyledFooter>
+        )}
+      </NavFlex>
+    </StyledContainer>
+  );
+};
+
+MainNavigation.Container = Container;
+MainNavigation.NavButtonContainer = NavButtonContainer;
+MainNavigation.Header = Header;
+MainNavigation.Body = Body;
+MainNavigation.Footer = Footer;
+// if using server-side rendering these will not work, since they use window.location, and should be handled outside the component
+MainNavigation.getScrollSpeed = getGetScrollSpeed;
+MainNavigation.getScrollPosition = getScrollPosition;
+
+export default MainNavigation;

--- a/src/components/MainNavigation/__test__/MainNavigation.test.tsx
+++ b/src/components/MainNavigation/__test__/MainNavigation.test.tsx
@@ -1,0 +1,96 @@
+import React from 'react';
+import { render, fireEvent, waitFor, configure } from '@testing-library/react';
+import MainNavigation from '../MainNavigation';
+import { axe, toHaveNoViolations } from 'jest-axe';
+
+expect.extend(toHaveNoViolations);
+configure({ testIdAttribute: 'data-test-id' });
+
+const testId = 'hs-ui-main-navigation-unit-test';
+
+describe('MainNavigation', () => {
+  it('renders', async () => {
+    const { container, getByTestId } = render(
+      <MainNavigation containerProps={{ 'data-test-id': testId }} />,
+    );
+
+    await waitFor(() => getByTestId(testId));
+    expect(container).toMatchSnapshot();
+  });
+
+  it('nav button clicks', async () => {
+    const { container, getByTestId } = render(
+      <MainNavigation
+        navButtons={[
+          {
+            label: 'Test link',
+            onClick: () => {},
+          },
+        ]}
+        navButtonProps={[{ 'data-test-id': testId + '-click' }]}
+      />,
+    );
+
+    await waitFor(() => getByTestId(testId + '-click'));
+    fireEvent.mouseDown(getByTestId(testId + '-click'));
+    expect(container).toMatchSnapshot();
+  });
+
+  describe('Accessibility Tests', () => {
+    it('Should pass accessibility test with default props', async () => {
+      const component = <MainNavigation />;
+      const { container } = render(component);
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+  });
+  describe('Ref tests', () => {
+    it('containerRef.current should exist', async () => {
+      const containerRef = React.createRef<HTMLDivElement>();
+      const { getByTestId } = render(
+        <MainNavigation
+          containerRef={containerRef}
+          containerProps={{ 'data-test-id': testId + '-container-ref' }}
+        />,
+      );
+      await waitFor(() => getByTestId(testId + '-container-ref'));
+      expect(containerRef.current instanceof HTMLDivElement).toBeTruthy();
+    });
+    it('headerRef.current should exist', async () => {
+      const headerRef = React.createRef<HTMLDivElement>();
+      const { getByTestId } = render(
+        <MainNavigation
+          headerRef={headerRef}
+          header={<div></div>}
+          headerProps={{ 'data-test-id': testId + '-header-ref' }}
+        />,
+      );
+      await waitFor(() => getByTestId(testId + '-header-ref'));
+      expect(headerRef.current instanceof HTMLDivElement).toBeTruthy();
+    });
+    it('bodyRef.current should exist', async () => {
+      const bodyRef = React.createRef<HTMLDivElement>();
+      const { getByTestId } = render(
+        <MainNavigation
+          bodyRef={bodyRef}
+          body={<div></div>}
+          bodyProps={{ 'data-test-id': testId + '-body-ref' }}
+        />,
+      );
+      await waitFor(() => getByTestId(testId + '-body-ref'));
+      expect(bodyRef.current instanceof HTMLDivElement).toBeTruthy();
+    });
+    it('footerRef.current should exist', async () => {
+      const footerRef = React.createRef<HTMLDivElement>();
+      const { getByTestId } = render(
+        <MainNavigation
+          footerRef={footerRef}
+          footer={<div></div>}
+          footerProps={{ 'data-test-id': testId + '-footer-ref' }}
+        />,
+      );
+      await waitFor(() => getByTestId(testId + '-footer-ref'));
+      expect(footerRef.current instanceof HTMLDivElement).toBeTruthy();
+    });
+  });
+});

--- a/src/components/MainNavigation/__test__/__snapshots__/MainNavigation.test.tsx.snap
+++ b/src/components/MainNavigation/__test__/__snapshots__/MainNavigation.test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`MainNavigation nav button clicks 1`] = `
-.c9 {
+.c10 {
   opacity: 0;
   background: linear-gradient( 90deg, rgba(255,255,255,0.75), rgba(255,255,255,0.25), rgba(255,255,255,0.75) ) repeat;
   color: transparent;
@@ -32,11 +32,11 @@ exports[`MainNavigation nav button clicks 1`] = `
   transition: opacity .2s;
 }
 
-.c10 {
+.c11 {
   position: relative;
 }
 
-.c12 {
+.c13 {
   pointer-events: none;
   position: absolute;
   top: 0;
@@ -58,7 +58,7 @@ exports[`MainNavigation nav button clicks 1`] = `
   outline: 0 none;
   border: 1px solid transparent;
   cursor: pointer;
-  background-color: #0000;
+  background-color: #BF3A00;
   color: #fff;
   -webkit-user-select: none;
   -moz-user-select: none;
@@ -71,7 +71,7 @@ exports[`MainNavigation nav button clicks 1`] = `
 }
 
 .c5:hover {
-  background-color: rgba(0,0,0,0);
+  background-color: #a63200;
 }
 
 .c5:focus {
@@ -79,7 +79,7 @@ exports[`MainNavigation nav button clicks 1`] = `
   box-shadow: 0 0 5px 0.150rem #338BAA;
 }
 
-.c11 {
+.c12 {
   position: absolute;
   width: 100%;
   height: 100%;
@@ -87,7 +87,7 @@ exports[`MainNavigation nav button clicks 1`] = `
   top: 0;
 }
 
-.c13 {
+.c14 {
   border-radius: 0.25em;
 }
 
@@ -96,7 +96,7 @@ exports[`MainNavigation nav button clicks 1`] = `
   color: #fff;
 }
 
-.c8 {
+.c9 {
   display: inline;
 }
 
@@ -156,21 +156,24 @@ exports[`MainNavigation nav button clicks 1`] = `
 }
 
 .c6 {
+  -webkit-align-self: stretch;
+  -ms-flex-item-align: stretch;
+  align-self: stretch;
   width: -webkit-fit-content;
   width: -moz-fit-content;
   width: fit-content;
-  padding: 0.25rem 0rem 0.25rem 1rem;
-  height: 100%;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
   border-radius: 0 0 0 0;
-}
-
-.c6:hover {
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
 }
 
 .c6:focus {
   box-shadow: 0 0 0;
+}
+
+.c8:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
 }
 
 <div>
@@ -187,19 +190,19 @@ exports[`MainNavigation nav button clicks 1`] = `
       >
         <button
           class=" c4 c5 c6"
-          color="#0000"
+          color="#BF3A00"
           data-test-id="hs-ui-main-navigation-unit-test-click"
           elevation="0"
           role="button"
           type="button"
         >
           <span
-            class=" c7"
+            class=" c7 c8"
             color="#fff"
             data-test-id="hsui-Text"
           >
             <div
-              class=" c4 c8"
+              class=" c4 c9"
             >
               <span
                 class=" "
@@ -207,23 +210,23 @@ exports[`MainNavigation nav button clicks 1`] = `
                 Test link
               </span>
               <div
-                class=" c9"
+                class=" c10"
                 color="#fff"
               />
             </div>
           </span>
           <div
-            class="c10 c11"
+            class="c11 c12"
           >
             <svg
-              class="c12 c13"
+              class="c13 c14"
               height="0px"
               viewBox="0 0 0 0"
               width="0px"
             />
           </div>
           <div
-            class=" c9"
+            class=" c10"
             color="#fff"
           />
         </button>

--- a/src/components/MainNavigation/__test__/__snapshots__/MainNavigation.test.tsx.snap
+++ b/src/components/MainNavigation/__test__/__snapshots__/MainNavigation.test.tsx.snap
@@ -1,0 +1,304 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`MainNavigation nav button clicks 1`] = `
+.c9 {
+  opacity: 0;
+  background: linear-gradient( 90deg, rgba(255,255,255,0.75), rgba(255,255,255,0.25), rgba(255,255,255,0.75) ) repeat;
+  color: transparent;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  pointer-events: none;
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-size: 100vw 100vh;
+  background-attachment: fixed;
+  border-radius: 0.25rem;
+  -webkit-animation: gZwmnl 2s linear infinite;
+  animation: gZwmnl 2s linear infinite;
+}
+
+.c4 {
+  display: block;
+  position: relative;
+}
+
+.c4 > * {
+  -webkit-transition: opacity .2s;
+  transition: opacity .2s;
+}
+
+.c10 {
+  position: relative;
+}
+
+.c12 {
+  pointer-events: none;
+  position: absolute;
+  top: 0;
+  left: 0;
+}
+
+.c5 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  font-size: 1em;
+  padding: .75em 1em;
+  border-radius: 0.25em;
+  -webkit-transition: background-color .2s, color .5s, outline .5s, filter .5s, box-shadow .5s;
+  transition: background-color .2s, color .5s, outline .5s, filter .5s, box-shadow .5s;
+  contain: layout;
+  outline: 0 none;
+  border: 1px solid transparent;
+  cursor: pointer;
+  background-color: #0000;
+  color: #fff;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c5:hover {
+  background-color: rgba(0,0,0,0);
+}
+
+.c5:focus {
+  outline: none;
+  box-shadow: 0 0 5px 0.150rem #338BAA;
+}
+
+.c11 {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  left: 0;
+  top: 0;
+}
+
+.c13 {
+  border-radius: 0.25em;
+}
+
+.c7 {
+  font-size: 1rem;
+  color: #fff;
+}
+
+.c8 {
+  display: inline;
+}
+
+.c0 {
+  position: relative;
+  background-color: #BF3A00;
+  color: #fff;
+  height: 3rem;
+  width: 100%;
+  -webkit-transform: scaleY(1);
+  -ms-transform: scaleY(1);
+  transform: scaleY(1);
+  -webkit-transform-origin: top;
+  -ms-transform-origin: top;
+  transform-origin: top;
+  -webkit-transition: -webkit-transform 0.1s cubic-bezier(0,.7,.9,1);
+  -webkit-transition: transform 0.1s cubic-bezier(0,.7,.9,1);
+  transition: transform 0.1s cubic-bezier(0,.7,.9,1);
+}
+
+.c1 {
+  height: 100%;
+  width: 100%;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-align-content: stretch;
+  -ms-flex-line-pack: stretch;
+  align-content: stretch;
+  padding-left: 1rem;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  height: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c3 {
+  width: 100%;
+}
+
+.c6 {
+  width: -webkit-fit-content;
+  width: -moz-fit-content;
+  width: fit-content;
+  padding: 0.25rem 0.5rem 0.25rem 0.5rem;
+  height: 100%;
+  border-radius: 0 0 0 0;
+}
+
+.c6:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c6:focus {
+  box-shadow: 0 0 0;
+}
+
+<div>
+  <div
+    class=" c0"
+    color="#BF3A00"
+    height="3rem"
+  >
+    <div
+      class=" c1"
+    >
+      <div
+        class=" c2 c3"
+      >
+        <button
+          class=" c4 c5 c6"
+          color="#0000"
+          data-test-id="hs-ui-main-navigation-unit-test-click"
+          elevation="0"
+          role="button"
+          type="button"
+        >
+          <span
+            class=" c7"
+            color="#fff"
+            data-test-id="hsui-Text"
+          >
+            <div
+              class=" c4 c8"
+            >
+              <span
+                class=" "
+              >
+                Test link
+              </span>
+              <div
+                class=" c9"
+                color="#fff"
+              />
+            </div>
+          </span>
+          <div
+            class="c10 c11"
+          >
+            <svg
+              class="c12 c13"
+              height="0px"
+              viewBox="0 0 0 0"
+              width="0px"
+            />
+          </div>
+          <div
+            class=" c9"
+            color="#fff"
+          />
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`MainNavigation renders 1`] = `
+.c0 {
+  position: relative;
+  background-color: #BF3A00;
+  color: #fff;
+  height: 3rem;
+  width: 100%;
+  -webkit-transform: scaleY(1);
+  -ms-transform: scaleY(1);
+  transform: scaleY(1);
+  -webkit-transform-origin: top;
+  -ms-transform-origin: top;
+  transform-origin: top;
+  -webkit-transition: -webkit-transform 0.1s cubic-bezier(0,.7,.9,1);
+  -webkit-transition: transform 0.1s cubic-bezier(0,.7,.9,1);
+  transition: transform 0.1s cubic-bezier(0,.7,.9,1);
+}
+
+.c1 {
+  height: 100%;
+  width: 100%;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-align-content: stretch;
+  -ms-flex-line-pack: stretch;
+  align-content: stretch;
+  padding-left: 1rem;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  height: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c3 {
+  width: 100%;
+}
+
+<div>
+  <div
+    class=" c0"
+    color="#BF3A00"
+    data-test-id="hs-ui-main-navigation-unit-test"
+    height="3rem"
+  >
+    <div
+      class=" c1"
+    >
+      <div
+        class=" c2 c3"
+      />
+    </div>
+  </div>
+</div>
+`;

--- a/src/components/MainNavigation/__test__/__snapshots__/MainNavigation.test.tsx.snap
+++ b/src/components/MainNavigation/__test__/__snapshots__/MainNavigation.test.tsx.snap
@@ -104,7 +104,9 @@ exports[`MainNavigation nav button clicks 1`] = `
   position: relative;
   background-color: #BF3A00;
   color: #fff;
-  height: 3rem;
+  height: -webkit-fit-content;
+  height: -moz-fit-content;
+  height: fit-content;
   width: 100%;
   -webkit-transform: scaleY(1);
   -ms-transform: scaleY(1);
@@ -124,9 +126,6 @@ exports[`MainNavigation nav button clicks 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -138,15 +137,18 @@ exports[`MainNavigation nav button clicks 1`] = `
 }
 
 .c2 {
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
   height: 100%;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
 }
 
 .c3 {
@@ -157,7 +159,7 @@ exports[`MainNavigation nav button clicks 1`] = `
   width: -webkit-fit-content;
   width: -moz-fit-content;
   width: fit-content;
-  padding: 0.25rem 0.5rem 0.25rem 0.5rem;
+  padding: 0.25rem 0rem 0.25rem 1rem;
   height: 100%;
   border-radius: 0 0 0 0;
 }
@@ -175,7 +177,7 @@ exports[`MainNavigation nav button clicks 1`] = `
   <div
     class=" c0"
     color="#BF3A00"
-    height="3rem"
+    height="fit-content"
   >
     <div
       class=" c1"
@@ -236,7 +238,9 @@ exports[`MainNavigation renders 1`] = `
   position: relative;
   background-color: #BF3A00;
   color: #fff;
-  height: 3rem;
+  height: -webkit-fit-content;
+  height: -moz-fit-content;
+  height: fit-content;
   width: 100%;
   -webkit-transform: scaleY(1);
   -ms-transform: scaleY(1);
@@ -256,9 +260,6 @@ exports[`MainNavigation renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -270,15 +271,18 @@ exports[`MainNavigation renders 1`] = `
 }
 
 .c2 {
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
   height: 100%;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
 }
 
 .c3 {
@@ -290,7 +294,7 @@ exports[`MainNavigation renders 1`] = `
     class=" c0"
     color="#BF3A00"
     data-test-id="hs-ui-main-navigation-unit-test"
-    height="3rem"
+    height="fit-content"
   >
     <div
       class=" c1"

--- a/src/components/MainNavigation/index.ts
+++ b/src/components/MainNavigation/index.ts
@@ -1,0 +1,3 @@
+import MainNavigation from "./MainNavigation";
+
+export default MainNavigation;

--- a/src/components/MainNavigation/index.ts
+++ b/src/components/MainNavigation/index.ts
@@ -1,3 +1,3 @@
-import MainNavigation from "./MainNavigation";
+import MainNavigation from './MainNavigation';
 
 export default MainNavigation;

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import Divider from './components/Divider';
 import Dropdown from './components/Dropdown';
 import InteractionFeedback from './components/InteractionFeedback';
 import Label from './components/Label';
+import MainNavigation from './components/MainNavigation';
 import Modal from './components/Modal';
 import RangeSlider from './components/RangeSlider';
 import Spotlight from './components/Spotlight';
@@ -31,6 +32,7 @@ export {
   Dropdown,
   InteractionFeedback,
   Label,
+  MainNavigation,
   Modal,
   RangeSlider,
   Skeleton,


### PR DESCRIPTION
Added a top navigation bar component. It accepts react nodes for header, body, and footer. The body will also accept `navButtons`, which are links in the form of buttons with `onClick`s, for an easy API for simple navigation. The body can also be hidden with `hideBody` or placed beneath the main bar with `bodyBelow`. It also exposes functions for getting scroll position and scroll speed for those utilizing client-side rendering (SSR must be custom). 