### PR TITLE
Changed default webpack builder to Webpack4 from Webpack5

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,10 +1,7 @@
 module.exports = {
   stories: ['../src/components/**/*.stories.tsx', '../src/**/*.stories.@(js|mdx)'],
-  addons: [
-    '@storybook/addon-links',
-    '@storybook/addon-essentials',
-    '@storybook/preset-create-react-app',
-    'storybook-addon-designs',
-    '@storybook/addon-a11y',
-  ],
+  addons: ['@storybook/addon-links', '@storybook/addon-essentials', '@storybook/preset-create-react-app', 'storybook-addon-designs', '@storybook/addon-a11y'],
+  core: {
+    builder: "webpack4"
+  }
 };


### PR DESCRIPTION
This change seems to have fixed some compatibility issues involving Webpack5 that result in a failed build upon fresh install/build of the repo.