### PR TITLE
fix(analytics): safely access props, as it can be undefined

### DIFF
--- a/src/components/Toggle/__tests__/Toggle.test.tsx
+++ b/src/components/Toggle/__tests__/Toggle.test.tsx
@@ -19,7 +19,20 @@ describe('Toggle', () => {
 
   describe('Accessibility Tests', () => {
     it('Should pass accessibility test with default props', async () => {
-      const component = <Toggle onToggle={() => {}} inputProps={{ 'aria-label': 'test' }}></Toggle>;
+      const component = (
+        <Toggle
+          onToggle={() => {}}
+          inputProps={{
+            'aria-label': 'test',
+            // forcing this aria-checked attribute, as jest-axe requires it,
+            // but useSwitch from react-aria no longer generates it.
+            // https://github.com/adobe/react-spectrum/pull/3687
+            // https://github.com/adobe/react-spectrum/issues/1264
+            // https://github.com/adobe/react-spectrum/issues/3130
+            'aria-checked': false,
+          }}
+        ></Toggle>
+      );
       const { container } = render(component);
       const results = await axe(container);
       expect(container).toMatchSnapshot();

--- a/src/context/index.tsx
+++ b/src/context/index.tsx
@@ -55,8 +55,8 @@ export const defaultAnalyticsFunction: AnalyticsFunctionType = (
   dateTime,
   deviceInfo,
   currentURL,
-  name: 'name' in props ? props.name : 'No name provided',
-  analytics: 'analytics' in props ? props.analytics : 'No analytics object provided',
+  name: props?.name ?? 'No name provided',
+  analytics: props?.analytics ?? 'No analytics object provided',
 });
 
 export const defaultAccessibilityPreferences: AccessibilityPreferences = {


### PR DESCRIPTION
analytics props can be undefined, so we should access it with that in mind