### PR TITLE
Fixes #379 #434

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -89,7 +89,9 @@ const SkeletonButtonContainer = React.forwardRef(
   ),
 );
 
-export const ButtonContainer: StyledSubcomponentType = styled(SkeletonButtonContainer)`
+export const ButtonContainer: StyledSubcomponentType<{ as: string }> = styled(
+  SkeletonButtonContainer,
+)`
   ${({ disabled, elevation = 0, color, variant, feedbackType }: ButtonContainerProps) => {
     const { colors } = useTheme();
     const backgroundColor = getBackgroundColorFromVariant(variant, color, colors.transparent);

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,4 +1,4 @@
-import React, { ComponentProps, PropsWithChildren, ReactNode, forwardRef } from 'react';
+import React, { ComponentProps, PropsWithChildren, ReactNode } from 'react';
 import UnstyledIcon from '@mdi/react';
 import { mdiLoading } from '@mdi/js';
 import styled from 'styled-components';
@@ -80,11 +80,13 @@ export type ButtonProps = {
   onMouseUp?: (e: React.MouseEvent) => void;
 };
 
-const SkeletonButtonContainer = React.forwardRef((props: PropsWithChildren, ref) => (
-  <Skeleton.Container ref={ref} as={StyledBaseButton} {...props}>
-    {props.children}
-  </Skeleton.Container>
-));
+const SkeletonButtonContainer = React.forwardRef(
+  (props: PropsWithChildren<SubcomponentPropsType>, ref) => (
+    <Skeleton.Container ref={ref} as={StyledBaseButton} {...props}>
+      {props.children}
+    </Skeleton.Container>
+  ),
+);
 
 export const ButtonContainer = styled(SkeletonButtonContainer)`
   ${({ disabled, elevation = 0, color, variant, feedbackType }: ButtonContainerProps) => {

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,9 +1,10 @@
-import React, { ComponentProps, ReactNode } from 'react';
+import React, { ComponentProps, PropsWithChildren, ReactNode, forwardRef } from 'react';
 import UnstyledIcon from '@mdi/react';
 import { mdiLoading } from '@mdi/js';
-import styled, { StyledComponentBase } from 'styled-components';
+import styled from 'styled-components';
 import { darken } from 'polished';
 
+import FeedbackTypes from '../../enums/feedbackTypes';
 import timings from '../../enums/timings';
 import { useAnalytics, useTheme } from '../../context';
 import variants from '../../enums/variants';
@@ -19,7 +20,6 @@ import { SubcomponentPropsType, StyledSubcomponentType } from '../commonTypes';
 import { getShadowStyle } from '../../utils/styles';
 import InteractionFeedback from '../InteractionFeedback';
 import { InteractionFeedbackProps } from '../InteractionFeedback/InteractionFeedback';
-import FeedbackTypes from 'src/enums/feedbackTypes';
 
 export type ButtonContainerProps = {
   elevation: number;
@@ -80,11 +80,13 @@ export type ButtonProps = {
   onMouseUp?: (e: React.MouseEvent) => void;
 };
 
-const SkeletonButtonContainer = ({ children, ...props }: ComponentProps<typeof Skeleton.Container>) => <Skeleton.Container as={StyledBaseButton} {...props}>{children}</Skeleton.Container>;
+const SkeletonButtonContainer = React.forwardRef((props: PropsWithChildren, ref) => (
+  <Skeleton.Container ref={ref} as={StyledBaseButton} {...props}>
+    {props.children}
+  </Skeleton.Container>
+));
 
-export const ButtonContainer = styled(
-  SkeletonButtonContainer,
-)`
+export const ButtonContainer = styled(SkeletonButtonContainer)`
   ${({ disabled, elevation = 0, color, variant, feedbackType }: ButtonContainerProps) => {
     const { colors } = useTheme();
     const backgroundColor = getBackgroundColorFromVariant(variant, color, colors.transparent);
@@ -218,6 +220,8 @@ const Button = ({
   const mergedContainerProps = {
     id,
     isLoading,
+    role: 'button',
+    ref: containerRef,
     onClick: (e: any) => handleEventWithAnalytics('Button', onClick, 'onClick', e, containerProps),
     onBlur: (e: any) => handleEventWithAnalytics('Button', onBlur, 'onBlur', e, containerProps),
     onFocus: (e: any) => handleEventWithAnalytics('Button', onFocus, 'onFocus', e, containerProps),
@@ -234,7 +238,7 @@ const Button = ({
   };
 
   return (
-    <StyledContainer ref={containerRef} role="button" {...mergedContainerProps}>
+    <StyledContainer {...mergedContainerProps}>
       {!isProcessing &&
         iconPrefix &&
         (typeof iconPrefix === 'string' && iconPrefix !== '' ? (

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -243,6 +243,8 @@ const Button = ({
   };
 
   return (
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-expect-error "as" not allowed on StyledSubcomponentType. Passing as prop through containerProps still works.
     <StyledContainer {...mergedContainerProps}>
       {!isProcessing &&
         iconPrefix &&

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -21,13 +21,14 @@ import { getShadowStyle } from '../../utils/styles';
 import InteractionFeedback from '../InteractionFeedback';
 import { InteractionFeedbackProps } from '../InteractionFeedback/InteractionFeedback';
 
-export type ButtonContainerProps = {
+export type ButtonContainerProps = React.HTMLProps<HTMLButtonElement> & {
   elevation: number;
   color: string;
   variant: variants;
   type: string;
   disabled: boolean;
   feedbackType: FeedbackTypes;
+  isLoading?: boolean;
 };
 
 export enum ButtonTypes {
@@ -37,7 +38,7 @@ export enum ButtonTypes {
 }
 
 export type ButtonProps = {
-  StyledContainer?: StyledSubcomponentType<ButtonContainerProps>;
+  StyledContainer?: StyledSubcomponentType;
   // TODO: rename these to StyledIconPrefixContainer - etc
   StyledLeftIconContainer?: StyledSubcomponentType;
   StyledRightIconContainer?: StyledSubcomponentType;
@@ -88,7 +89,7 @@ const SkeletonButtonContainer = React.forwardRef(
   ),
 );
 
-export const ButtonContainer = styled(SkeletonButtonContainer)`
+export const ButtonContainer: StyledSubcomponentType = styled(SkeletonButtonContainer)`
   ${({ disabled, elevation = 0, color, variant, feedbackType }: ButtonContainerProps) => {
     const { colors } = useTheme();
     const backgroundColor = getBackgroundColorFromVariant(variant, color, colors.transparent);
@@ -219,23 +220,23 @@ const Button = ({
   const handleEventWithAnalytics = useAnalytics();
 
   // get everything we expose + anything consumer wants to send to container
-  const mergedContainerProps = {
+  const mergedContainerProps: ButtonContainerProps = {
     id,
     isLoading,
     role: 'button',
     ref: containerRef,
-    onClick: (e: any) => handleEventWithAnalytics('Button', onClick, 'onClick', e, containerProps),
-    onBlur: (e: any) => handleEventWithAnalytics('Button', onBlur, 'onBlur', e, containerProps),
-    onFocus: (e: any) => handleEventWithAnalytics('Button', onFocus, 'onFocus', e, containerProps),
-    onMouseDown: (e: any) =>
-      handleEventWithAnalytics('Button', onMouseDown, 'onMouseDown', e, containerProps),
-    onMouseUp: (e: any) =>
-      handleEventWithAnalytics('Button', onMouseUp, 'onMouseUp', e, containerProps),
     elevation,
     color: containerColor,
     variant,
     type,
     disabled,
+    feedbackType,
+    onClick: e => handleEventWithAnalytics('Button', onClick, 'onClick', e, containerProps),
+    onBlur: e => handleEventWithAnalytics('Button', onBlur, 'onBlur', e, containerProps),
+    onFocus: e => handleEventWithAnalytics('Button', onFocus, 'onFocus', e, containerProps),
+    onMouseDown: e =>
+      handleEventWithAnalytics('Button', onMouseDown, 'onMouseDown', e, containerProps),
+    onMouseUp: e => handleEventWithAnalytics('Button', onMouseUp, 'onMouseUp', e, containerProps),
     ...containerProps,
   };
 

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -19,7 +19,7 @@ import { SubcomponentPropsType, StyledSubcomponentType } from '../commonTypes';
 import { getShadowStyle } from '../../utils/styles';
 import InteractionFeedback from '../InteractionFeedback';
 import { InteractionFeedbackProps } from '../InteractionFeedback/InteractionFeedback';
-import FeedbackTypes from '../../enums/feedbackTypes';
+import FeedbackTypes from 'src/enums/feedbackTypes';
 
 export type ButtonContainerProps = {
   elevation: number;
@@ -37,7 +37,7 @@ export enum ButtonTypes {
 }
 
 export type ButtonProps = {
-  StyledContainer?: string & StyledComponentBase<any, {}, ButtonContainerProps>;
+  StyledContainer?: StyledSubcomponentType<ButtonContainerProps>;
   // TODO: rename these to StyledIconPrefixContainer - etc
   StyledLeftIconContainer?: StyledSubcomponentType;
   StyledRightIconContainer?: StyledSubcomponentType;
@@ -80,8 +80,10 @@ export type ButtonProps = {
   onMouseUp?: (e: React.MouseEvent) => void;
 };
 
-export const ButtonContainer: string & StyledComponentBase<any, {}, ButtonContainerProps> = styled(
-  Skeleton.Container,
+const SkeletonButtonContainer = ({ children, ...props }: ComponentProps<typeof Skeleton.Container>) => <Skeleton.Container as={StyledBaseButton} {...props}>{children}</Skeleton.Container>;
+
+export const ButtonContainer = styled(
+  SkeletonButtonContainer,
 )`
   ${({ disabled, elevation = 0, color, variant, feedbackType }: ButtonContainerProps) => {
     const { colors } = useTheme();
@@ -214,7 +216,6 @@ const Button = ({
 
   // get everything we expose + anything consumer wants to send to container
   const mergedContainerProps = {
-    as: StyledBaseButton,
     id,
     isLoading,
     onClick: (e: any) => handleEventWithAnalytics('Button', onClick, 'onClick', e, containerProps),

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -38,7 +38,7 @@ export enum ButtonTypes {
 }
 
 export type ButtonProps = {
-  StyledContainer?: StyledSubcomponentType;
+  StyledContainer?: StyledSubcomponentType<any>;
   // TODO: rename these to StyledIconPrefixContainer - etc
   StyledLeftIconContainer?: StyledSubcomponentType;
   StyledRightIconContainer?: StyledSubcomponentType;
@@ -89,9 +89,7 @@ const SkeletonButtonContainer = React.forwardRef(
   ),
 );
 
-export const ButtonContainer: StyledSubcomponentType<{ as: string }> = styled(
-  SkeletonButtonContainer,
-)`
+export const ButtonContainer: StyledSubcomponentType = styled(SkeletonButtonContainer)`
   ${({ disabled, elevation = 0, color, variant, feedbackType }: ButtonContainerProps) => {
     const { colors } = useTheme();
     const backgroundColor = getBackgroundColorFromVariant(variant, color, colors.transparent);

--- a/src/components/Table/Table.stories.tsx
+++ b/src/components/Table/Table.stories.tsx
@@ -8,7 +8,7 @@ import { name, address, company, commerce } from 'faker';
 
 import Table, { ExpansionIconColumnName } from './Table';
 import Checkbox from '../Checkbox/Checkbox';
-import { columnTypes, ExpansionIconProps } from './types';
+import { Columns, ExpansionIconProps } from './types';
 import { CheckboxTypes } from '../../enums/checkboxTypes';
 
 type SampleDataType = {
@@ -179,7 +179,7 @@ export const Default: Story<DefaultProps> = ({
     </ActionCellContainer>
   );
 
-  const sampleColumns: { [index: string]: any } = {
+  const sampleColumns: Columns = {
     selection: {
       name: '',
       headerCellComponent: SelectAllCell,
@@ -192,6 +192,8 @@ export const Default: Story<DefaultProps> = ({
       name: 'Name',
       width: nameWidth,
       footerContent: 'NameFooter',
+      sortable: true,
+      sortFunction: (name1: string, name2: string) => name1 > name2,
     },
     title: {
       name: 'Title',
@@ -208,7 +210,7 @@ export const Default: Story<DefaultProps> = ({
       width: notesWidth,
       cellComponent: NotesCell,
       minTableWidth: 800,
-      sortFunction: (a: string, b: string) => (a.length > b.length ? -1 : 1),
+      sortFunction: (a: string, b: string) => a.length > b.length,
       footerContent: 'NotesFooter',
     },
     action: {
@@ -220,7 +222,7 @@ export const Default: Story<DefaultProps> = ({
     },
   };
 
-  return <Table columns={sampleColumns} data={rows as columnTypes[]} />;
+  return <Table columns={sampleColumns} data={rows as Columns[]} />;
 };
 Default.args = {
   'Selection width': '2rem',
@@ -340,7 +342,7 @@ export const Groups: Story<GroupsProps> = ({
     </Table.Cell>
   );
 
-  const sampleColumns: { [index: string]: any } = {
+  const sampleColumns: Columns = {
     selection: {
       name: '',
       headerCellComponent: SelectAllCell,
@@ -353,26 +355,24 @@ export const Groups: Story<GroupsProps> = ({
     name: {
       name: 'Name',
       width: nameWidth,
-      // footerContent: 'NameFooter',
+      sortable: true,
+      sortFunction: (name1: string, name2: string) => name1 > name2,
     },
     title: {
       name: 'Title',
       width: titleWidth,
-      // footerContent: 'TitleFooter',
     },
     address: {
       name: 'Address',
       width: addressWidth,
-      // footerContent: 'AddressFooter',
     },
     notes: {
       name: 'Notes',
       width: notesWidth,
       cellComponent: NotesCell,
       minTableWidth: 800,
-      sortFunction: (a: string, b: string) => (a.length > b.length ? -1 : 1),
+      sortFunction: (a: string, b: string) => a.length > b.length,
       groupCellComponent: EmptyCell,
-      // footerContent: 'NotesFooter',
     },
   };
 
@@ -389,7 +389,8 @@ export const Groups: Story<GroupsProps> = ({
   return (
     <Table
       columns={sampleColumns}
-      data={rows as columnTypes[][]}
+      // TODO change data to type any
+      data={rows as Columns[][]}
       sortGroups={sortGroups}
       groupHeaderPosition={position}
       areGroupsCollapsible={areGroupsCollapsible}

--- a/src/components/Table/Table.stories.tsx
+++ b/src/components/Table/Table.stories.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { Story, Meta } from '@storybook/react';
 
-import styled, { StyledComponent, StyledComponentBase } from 'styled-components';
+import styled from 'styled-components';
 import Icon from '@mdi/react';
 import { mdiClose } from '@mdi/js';
 import { name, address, company, commerce } from 'faker';
@@ -10,7 +10,6 @@ import Table, { ExpansionIconColumnName } from './Table';
 import Checkbox from '../Checkbox/Checkbox';
 import { Columns, ExpansionIconProps, RowEntry } from './types';
 import { CheckboxTypes } from '../../enums/checkboxTypes';
-import { StyledSubcomponentType } from '../commonTypes';
 
 type SampleDataType = {
   name?: string;

--- a/src/components/Table/Table.stories.tsx
+++ b/src/components/Table/Table.stories.tsx
@@ -337,7 +337,11 @@ export const Groups: Story<GroupsProps> = ({
 
   const EmptyCell = () => <Table.Cell />;
 
-  const NotesCell = ({ notes }: { notes: string }) => (
+  interface NotesCellProps {
+    notes: string;
+  }
+
+  const NotesCell: React.FC<NotesCellProps> = ({ notes }) => (
     <Table.Cell>
       <NoteField onChange={() => {}} rows={3} value={notes} />
     </Table.Cell>
@@ -357,7 +361,6 @@ export const Groups: Story<GroupsProps> = ({
       name: 'Name',
       width: nameWidth,
       sortable: true,
-      sortFunction: (name1: string, name2: string) => name1 < name2,
     },
     title: {
       name: 'Title',

--- a/src/components/Table/Table.stories.tsx
+++ b/src/components/Table/Table.stories.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { Story, Meta } from '@storybook/react';
 
-import styled from 'styled-components';
+import styled, { StyledComponent, StyledComponentBase } from 'styled-components';
 import Icon from '@mdi/react';
 import { mdiClose } from '@mdi/js';
 import { name, address, company, commerce } from 'faker';
@@ -10,6 +10,7 @@ import Table, { ExpansionIconColumnName } from './Table';
 import Checkbox from '../Checkbox/Checkbox';
 import { Columns, ExpansionIconProps, RowEntry } from './types';
 import { CheckboxTypes } from '../../enums/checkboxTypes';
+import { StyledSubcomponentType } from '../commonTypes';
 
 type SampleDataType = {
   name?: string;

--- a/src/components/Table/Table.stories.tsx
+++ b/src/components/Table/Table.stories.tsx
@@ -8,7 +8,7 @@ import { name, address, company, commerce } from 'faker';
 
 import Table, { ExpansionIconColumnName } from './Table';
 import Checkbox from '../Checkbox/Checkbox';
-import { Columns, ExpansionIconProps } from './types';
+import { Columns, ExpansionIconProps, RowEntry } from './types';
 import { CheckboxTypes } from '../../enums/checkboxTypes';
 
 type SampleDataType = {
@@ -47,7 +47,7 @@ const NoteField = styled.textarea`
 `;
 
 const generateSampleData = (rows: number): SampleDataType[] => {
-  const finalData = [];
+  const finalData: Array<RowEntry> = [];
 
   for (let i = 0; i < rows; i += 1) {
     finalData.push({
@@ -62,9 +62,10 @@ const generateSampleData = (rows: number): SampleDataType[] => {
 };
 
 const generateSampleGroups = (numberOfGroups = 5, groupSize = 5): Array<SampleDataType[]> => {
-  const groupData = [];
+  const groupData: Array<Array<RowEntry>> = [];
   for (let i = 0; i < numberOfGroups; i++) {
     const groupRows = generateSampleData(groupSize);
+    // Add group title row
     groupRows.push({
       title: `${commerce.department()} Department`,
       isGroupLabel: true,
@@ -222,7 +223,7 @@ export const Default: Story<DefaultProps> = ({
     },
   };
 
-  return <Table columns={sampleColumns} data={rows as Columns[]} />;
+  return <Table columns={sampleColumns} data={rows} />;
 };
 Default.args = {
   'Selection width': '2rem',
@@ -389,8 +390,7 @@ export const Groups: Story<GroupsProps> = ({
   return (
     <Table
       columns={sampleColumns}
-      // TODO change data to type any
-      data={rows as Columns[][]}
+      data={rows}
       sortGroups={sortGroups}
       groupHeaderPosition={position}
       areGroupsCollapsible={areGroupsCollapsible}

--- a/src/components/Table/Table.stories.tsx
+++ b/src/components/Table/Table.stories.tsx
@@ -193,7 +193,6 @@ export const Default: Story<DefaultProps> = ({
       width: nameWidth,
       footerContent: 'NameFooter',
       sortable: true,
-      sortFunction: (name1: string, name2: string) => name1 > name2,
     },
     title: {
       name: 'Title',
@@ -210,7 +209,8 @@ export const Default: Story<DefaultProps> = ({
       width: notesWidth,
       cellComponent: NotesCell,
       minTableWidth: 800,
-      sortFunction: (a: string, b: string) => a.length > b.length,
+      sortable: true,
+      sortFunction: (a: string, b: string) => a.length < b.length,
       footerContent: 'NotesFooter',
     },
     action: {
@@ -356,7 +356,7 @@ export const Groups: Story<GroupsProps> = ({
       name: 'Name',
       width: nameWidth,
       sortable: true,
-      sortFunction: (name1: string, name2: string) => name1 > name2,
+      sortFunction: (name1: string, name2: string) => name1 < name2,
     },
     title: {
       name: 'Title',
@@ -371,7 +371,7 @@ export const Groups: Story<GroupsProps> = ({
       width: notesWidth,
       cellComponent: NotesCell,
       minTableWidth: 800,
-      sortFunction: (a: string, b: string) => a.length > b.length,
+      sortFunction: (a: string, b: string) => a.length < b.length,
       groupCellComponent: EmptyCell,
     },
   };

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -110,12 +110,11 @@ export const ResponsiveHeaderCell = styled(StyledBaseSpan)`
     const { colors } = useTheme();
     return `
       display: block;
-      padding: 1em 0;
       word-break: break-word;
       hyphens: auto;
       color: ${colors.primary};
-      padding: 0.5em;
       user-select: none;
+      padding: 0.5em;
       cursor: pointer;
       margin-right: .5em;
       background-color: rgba(0,0,0,0.05);
@@ -177,6 +176,7 @@ export const Cell = styled(StyledBaseTD)`
   word-break: break-word;
   hyphens: auto;
   width: unset;
+  padding: 0.5em;
 `;
 
 export const SortIcon = styled(Icon)`
@@ -192,7 +192,7 @@ export const SortIcon = styled(Icon)`
 
 const CellContainer = styled(StyledBaseDiv)`
   display: flex;
-  padding: 1em 0;
+  padding: 0.5em 0;
 `;
 
 /** Start of variables */
@@ -743,6 +743,7 @@ Table.Cell = Cell;
  */
 Table.Title = ResponsiveHeaderCell;
 Table.ResponsiveHeaderCell = ResponsiveHeaderCell;
+Table.CellContainer = CellContainer;
 Table.ExpansionIconColumnName = ExpansionIconColumnName;
 
 export default Table;

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -1,9 +1,10 @@
 import React, { useEffect, useState } from 'react';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import useResizeObserver from 'use-resize-observer/polyfilled';
 import { mdiArrowDown, mdiChevronDown, mdiChevronRight, mdiChevronUp } from '@mdi/js';
 import Icon from '@mdi/react';
 import {
+  StyledBaseDiv,
   StyledBaseSpan,
   StyledBaseTable,
   StyledBaseTD,
@@ -12,7 +13,8 @@ import {
 } from '../../htmlElements';
 import {
   CellOptions,
-  columnTypes,
+  ColumnType,
+  ColumnTypes,
   InternalExpansionIconProps,
   RowProps,
   TableProps,
@@ -20,7 +22,7 @@ import {
 import { useAnalytics, useTheme } from '../../context';
 import { mergeRefs } from '../../utils/refs';
 
-type collapsedState = Record<string, string>;
+type CollapsedState = Record<string, string>;
 
 /** Start of styled components */
 
@@ -105,10 +107,14 @@ export const FooterCell = styled(StyledBaseTH)`
   }
 `;
 
-export const ResponsiveTitle = styled(StyledBaseSpan)`
+export const ResponsiveHeaderCell = styled(StyledBaseSpan)`
   ${({ sortable }: { sortable: boolean }) => {
     const { colors } = useTheme();
     return `
+      display: block;
+      padding: 1em 0;
+      word-break: break-word;
+      hyphens: auto;
       color: ${colors.primary};
       padding: 0.5em;
       user-select: none;
@@ -124,11 +130,11 @@ export const ResponsiveTitle = styled(StyledBaseSpan)`
 export const Row = styled(StyledBaseTR)`
   ${({ columnGap, columnWidths, reachedMinWidth, isCollapsed = false }: RowProps) => {
     const { colors } = useTheme();
-    return `
+    return css`
       display: grid;
       grid-template-columns: ${reachedMinWidth ? '100%' : columnWidths};
       padding: ${reachedMinWidth ? '1em' : '0em'} 2em;
-      row-gap: .5em;
+      row-gap: 0.5em;
       column-gap: ${columnGap};
       position: relative;
       background-color: ${colors.background};
@@ -142,17 +148,18 @@ export const Row = styled(StyledBaseTR)`
         content: '';
         z-index: 0;
         position: absolute;
-        top: 0; left: 0;
+        top: 0;
+        left: 0;
         width: 100%;
         height: 100%;
-        background-color: rgba(0,0,0,0.2);
+        background-color: rgba(0, 0, 0, 0.2);
         opacity: 0;
-        transition: opacity .3s;
+        transition: opacity 0.3s;
 
         pointer-events: none;
       }
       &:hover:before {
-        opacity: .3;
+        opacity: 0.3;
       }
     `;
   }}
@@ -169,7 +176,6 @@ export const GroupRow = styled(Row)`
 
 export const Cell = styled(StyledBaseTD)`
   display: block;
-  padding: 1em 0;
   word-break: break-word;
   hyphens: auto;
   width: unset;
@@ -186,9 +192,14 @@ export const SortIcon = styled(Icon)`
   `}
 `;
 
+const CellContainer = styled(StyledBaseDiv)`
+  display: flex;
+  padding: 1em 0;
+`;
+
 /** Start of variables */
 
-const defaultCollapsed: collapsedState = {};
+const defaultCollapsed: CollapsedState = {};
 
 // Default expansion column added if there isn't one
 const collapsedExpandedIconColumn = {
@@ -255,21 +266,24 @@ const Table = ({
   StyledGroupLabelRow = GroupRow,
   StyledHeader = Header,
   StyledHeaderCell = HeaderCell,
+  StyledResponsiveHeaderCell = ResponsiveHeaderCell,
   StyledRow = Row,
   StyledFooter = Footer,
   StyledFooterCell = FooterCell,
+  StyledCellContainer = CellContainer,
+
   cellProps = {},
   containerProps = {},
   groupLabelRowProps = {},
   headerProps = {},
   headerCellProps = {},
+  responsiveHeaderCellProps = {},
   rowProps = {},
 
   containerRef,
   groupLabelRowRef,
   headerRef,
-  headerCellRef,
-}: TableProps) => {
+}: TableProps): JSX.Element => {
   const [sortedData, sortData] = useState(data);
   const [sortMethod, setSortMethod] = useState(defaultSort);
   const [collapsedGroups, setCollapsedGroups] = useState(defaultCollapsed);
@@ -283,7 +297,7 @@ const Table = ({
 
   // this builds the string from the columns
   const columnWidths = Object.values(copiedColumns)
-    .map((col: columnTypes[0]) => {
+    .map((col: ColumnTypes[0]) => {
       if (col.minTableWidth && width <= col.minTableWidth) {
         return '0px';
       }
@@ -300,7 +314,7 @@ const Table = ({
 
     // Make a copy of the dictionary-like object. Because this object
     // doesn't have nested objects, a shallow copy is fine
-    const temp: collapsedState = { ...collapsedGroups };
+    const temp: CollapsedState = { ...collapsedGroups };
     if (group) {
       delete temp[key];
     } else {
@@ -308,6 +322,29 @@ const Table = ({
     }
 
     setCollapsedGroups(temp);
+  };
+
+  /**
+   * A compare function that returns a comparison integer (1 or -1).
+   * Used to compare the values at one key across two different rows when sorting.
+   *
+   * `direction` is true for ascending, false for descending.
+   */
+  const compareEntries = (entry1: any, entry2: any, column: ColumnType, isAscending: boolean) => {
+    // If this column has a sort custom sort function, use it.
+    if (column && Object.prototype.hasOwnProperty.call(column, 'sortFunction')) {
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore Cannot invoke an object which is possibly 'undefined'.ts(2722)
+      const customComparison = column.sortFunction(entry1, entry2);
+      if (isAscending) {
+        return customComparison ? -1 : 1;
+      }
+      return customComparison ? 1 : -1;
+    }
+
+    // No sort function, use default comparison operator.
+    const comparison = isAscending ? entry1 < entry2 : entry1 > entry2;
+    return comparison ? -1 : 1;
   };
 
   /**
@@ -320,51 +357,23 @@ const Table = ({
   const onSort = (key: string, newDirection: boolean) => {
     // If the first element of the data is not an array, then we do not have groups
     if (!Array.isArray(data[0])) {
-      data.sort((a: any, b: any) => {
-        if (
-          copiedColumns[key] &&
-          Object.prototype.hasOwnProperty.call(copiedColumns[key], 'sortFunction')
-        ) {
-          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-          // @ts-ignore Cannot invoke an object which is possibly 'undefined'.ts(2722)
-          return copiedColumns[key].sortFunction(a[key], b[key]) ? -1 : 1;
-        }
-        const comparison = newDirection ? a[key] < b[key] : a[key] > b[key];
-        return comparison ? -1 : 1;
-      });
+      // No groups, sort all data
+      data.sort((row1: any, row2: any) =>
+        compareEntries(row1[key], row2[key], copiedColumns[key], newDirection),
+      );
     } else {
-      // Cast data to the appropariate type and iterate over each group, sorting their content
-      (data as Array<Array<columnTypes>>).forEach(group => {
-        group.sort((a: any, b: any) => {
-          if (
-            copiedColumns[key] &&
-            Object.prototype.hasOwnProperty.call(copiedColumns[key], 'sortFunction')
-          ) {
-            if (a.isGroupLabel || b.isGroupLabel) return 0;
-            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-            // @ts-ignore Cannot invoke an object which is possibly 'undefined'.ts(2722)
-            return copiedColumns[key].sortFunction(a[key], b[key]) ? -1 : 1;
-          }
-          const comparison = newDirection ? a[key] < b[key] : a[key] > b[key];
-          return comparison ? -1 : 1;
-        });
+      // Sort the content of each group
+      (data as Array<Array<ColumnTypes>>).forEach(() => {
+        data.sort((row1: any, row2: any) =>
+          compareEntries(row1[key], row2[key], copiedColumns[key], newDirection),
+        );
       });
 
-      // Sort the groups only if sortGroups is supplied as true
+      // Sort the groups
       if (sortGroups) {
-        (data as Array<Array<columnTypes>>).sort((a: any, b: any) => {
-          if (
-            copiedColumns[key] &&
-            Object.prototype.hasOwnProperty.call(copiedColumns[key], 'sortFunction')
-          ) {
-            if (a.isGroupLabel || b.isGroupLabel) return 0;
-            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-            // @ts-ignore Cannot invoke an object which is possibly 'undefined'.ts(2722)
-            return copiedColumns[key].sortFunction(a[0][key], b[0][key]) ? -1 : 1;
-          }
-          const comparison = newDirection ? a[0][key] < b[0][key] : a[0][key] > b[0][key];
-          return comparison ? -1 : 1;
-        });
+        (data as Array<Array<ColumnTypes>>).sort((group1: any, group2: any) =>
+          compareEntries(group1[0][key], group2[0][key], copiedColumns[key], newDirection),
+        );
       }
     }
 
@@ -395,7 +404,7 @@ const Table = ({
    * @param {any} options.RenderedCell - The component used as the cell
    * @param {string} options.headerColumnKey - The header column key for the cell
    * @param {boolean} options.breakPointHit - If the breakpoint has been hit for width
-   * @param {columnTypes} options.row - the data for the row, each cell should be able to the row's data
+   * @param {ColumnTypes} options.row - the data for the row, each cell should be able to the row's data
    * @param {number} options.index - The index of the cell in the row
    * @param {number} options.indexModifier - Used only when creating cells in a group. Used to account for group labels
    * @param {any} options.CollapseExpandedIcon - Component to be used for the collapse icon. Only used for collapsible group label cells
@@ -419,46 +428,52 @@ const Table = ({
   }: CellOptions): JSX.Element | false => {
     return (
       (!copiedColumns[headerColumnKey].minTableWidth || breakPointHit) && (
-        <RenderedCell
-          // all cells should have full access to all the data in the row
-          {...row}
-          index={index}
-          groupIndex={groupIndex}
-          reachedMinWidth={width < minWidthBreakpoint}
-          key={`${headerColumnKey}${index + indexModifier}`}
-          {...cellPropsInput}
-        >
-          {width < minWidthBreakpoint && (
-            <ResponsiveTitle
-              onClick={() => {
-                handleOnSort(
-                  headerColumnKey,
-                  headerColumnKey === sortMethod[0] ? !sortMethod[1] : true,
-                );
-              }}
-              sortable={copiedColumns[headerColumnKey].sortable}
-            >
-              {copiedColumns[headerColumnKey].name}
-              <SortIcon
-                direction={sortMethod[0] === headerColumnKey ? sortMethod[1] : null}
-                path={mdiArrowDown}
+        <StyledCellContainer>
+          {columns[headerColumnKey].name !== '' &&
+            width < minWidthBreakpoint &&
+            !groupLabelDataString && (
+              <StyledResponsiveHeaderCell
+                onClick={() => {
+                  handleOnSort(
+                    headerColumnKey,
+                    headerColumnKey === sortMethod[0] ? !sortMethod[1] : true,
+                  );
+                }}
+                sortable={copiedColumns[headerColumnKey].sortable}
+                {...responsiveHeaderCellProps}
+              >
+                {copiedColumns[headerColumnKey].name}
+                <SortIcon
+                  direction={sortMethod[0] === headerColumnKey ? sortMethod[1] : null}
+                  path={mdiArrowDown}
+                />
+              </StyledResponsiveHeaderCell>
+            )}
+
+          <RenderedCell
+            // all cells should have full access to all the data in the row
+            {...row}
+            index={index}
+            groupIndex={groupIndex}
+            reachedMinWidth={width < minWidthBreakpoint}
+            key={`${headerColumnKey}${index + indexModifier}`}
+            {...cellPropsInput}
+          >
+            {row && row[headerColumnKey]}
+            {CollapseExpandedIcon &&
+            usingGroups &&
+            areGroupsCollapsible &&
+            headerColumnKey === ExpansionIconColumnName ? (
+              <CollapseExpandedIcon
+                isCollapsed={isCollapsed}
+                groupHeaderPosition={groupHeaderPosition}
+                onClick={() => {
+                  toggleGroupCollapse((groupLabelDataString || JSON.stringify(row)) + groupIndex);
+                }}
               />
-            </ResponsiveTitle>
-          )}
-          {row && row[headerColumnKey]}
-          {CollapseExpandedIcon &&
-          usingGroups &&
-          areGroupsCollapsible &&
-          headerColumnKey === ExpansionIconColumnName ? (
-            <CollapseExpandedIcon
-              isCollapsed={isCollapsed}
-              groupHeaderPosition={groupHeaderPosition}
-              onClick={() => {
-                toggleGroupCollapse((groupLabelDataString || JSON.stringify(row)) + groupIndex);
-              }}
-            />
-          ) : null}
-        </RenderedCell>
+            ) : null}
+          </RenderedCell>
+        </StyledCellContainer>
       )
     );
   };
@@ -469,9 +484,11 @@ const Table = ({
   const createGroups = () => {
     // Generate groupings - Note that we are making shallow copies of the arrays so that we do not
     // modify the props directly since this is an Array of Arrays.
-    return [...(sortedData as Array<Array<columnTypes>>)].map(
-      (group: Array<columnTypes>, idx: number) => {
+    return [...(sortedData as Array<Array<ColumnTypes>>)].map(
+      (group: Array<ColumnTypes>, idx: number) => {
         const groupLabelIndex: number = group.findIndex(grp => {
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore
           return grp.isGroupLabel === true;
         });
 
@@ -490,9 +507,10 @@ const Table = ({
         const isCollapsed = !!collapsedGroups[groupLabelDataString + idx];
 
         // Generate the rows for this group
-        const rows = groupCopy.map((row: columnTypes, index: number) => {
+        const rows = groupCopy.map((row: ColumnTypes, index: number) => {
           const RenderedRow = row.rowComponent || StyledRow;
           if (index === groupLabelIndex) return null;
+
           return (
             // eslint-disable-next-line @typescript-eslint/ban-ts-comment
             // @ts-ignore - TS2604: JSX element type does not have any construct or call signatures
@@ -606,7 +624,7 @@ const Table = ({
 
     return (
       <tbody>
-        {(sortedData as Array<columnTypes>).map((row: columnTypes, index: number) => {
+        {(sortedData as Array<ColumnTypes>).map((row: ColumnTypes, index: number) => {
           // map over the rows
           const RenderedRow = row.rowComponent || StyledRow;
           // Rows.map return
@@ -619,6 +637,7 @@ const Table = ({
               rowNum={index}
               key={`row${JSON.stringify(row)}`}
               reachedMinWidth={width < minWidthBreakpoint}
+              {...rowProps}
             >
               {Object.keys(copiedColumns).map(headerColumnKey => {
                 const RenderedCell = copiedColumns[headerColumnKey].cellComponent || StyledCell;
@@ -678,7 +697,6 @@ const Table = ({
                       );
                     }}
                     sortable={copiedColumns[headerColumnKey].sortable}
-                    ref={headerCellRef}
                     {...headerCellProps}
                   >
                     {copiedColumns[headerColumnKey].name}
@@ -722,7 +740,11 @@ Table.HeaderCell = HeaderCell;
 Table.Row = Row;
 Table.GroupRow = GroupRow;
 Table.Cell = Cell;
-Table.Title = ResponsiveTitle;
+/**
+ * @deprecated use Table.ResponsiveTitle
+ */
+Table.Title = ResponsiveHeaderCell;
+Table.ResponsiveHeaderCell = ResponsiveHeaderCell;
 Table.ExpansionIconColumnName = ExpansionIconColumnName;
 
 export default Table;

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -176,7 +176,7 @@ export const Cell = styled(StyledBaseTD)`
   word-break: break-word;
   hyphens: auto;
   width: unset;
-  padding: 0.5em;
+  padding: 0.5em 0;
 `;
 
 export const SortIcon = styled(Icon)`

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -22,8 +22,6 @@ import {
 import { useAnalytics, useTheme } from '../../context';
 import { mergeRefs } from '../../utils/refs';
 
-type CollapsedState = Record<string, string>;
-
 /** Start of styled components */
 
 const StyledExpansionIconSpan = styled(StyledBaseSpan)`
@@ -199,7 +197,7 @@ const CellContainer = styled(StyledBaseDiv)`
 
 /** Start of variables */
 
-const defaultCollapsed: CollapsedState = {};
+const defaultCollapsed: Record<string, string> = {};
 
 // Default expansion column added if there isn't one
 const collapsedExpandedIconColumn = {
@@ -314,7 +312,7 @@ const Table = ({
 
     // Make a copy of the dictionary-like object. Because this object
     // doesn't have nested objects, a shallow copy is fine
-    const temp: CollapsedState = { ...collapsedGroups };
+    const temp = { ...collapsedGroups };
     if (group) {
       delete temp[key];
     } else {

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -519,6 +519,7 @@ const Table = ({
               key={`row${JSON.stringify(row) + index}`}
               reachedMinWidth={width < minWidthBreakpoint}
               isCollapsed={areGroupsCollapsible && isCollapsed}
+              {...row}
               {...rowProps}
             >
               {Object.keys(copiedColumns).map(headerColumnKey => {
@@ -566,6 +567,7 @@ const Table = ({
               key={`row${groupLabelDataString}`}
               reachedMinWidth={width < minWidthBreakpoint}
               ref={groupLabelRowRef}
+              {...groupLabelData}
               {...groupLabelRowProps}
             >
               {Object.keys(copiedColumns).map(headerColumnKey => {
@@ -635,6 +637,7 @@ const Table = ({
               rowNum={index}
               key={`row${JSON.stringify(row)}`}
               reachedMinWidth={width < minWidthBreakpoint}
+              {...row}
               {...rowProps}
             >
               {Object.keys(copiedColumns).map(headerColumnKey => {

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -528,7 +528,7 @@ const Table = ({
                 const breakPointHit =
                   width > (copiedColumns[headerColumnKey].minTableWidth || Infinity);
 
-                const options = {
+                const options: CellOptions = {
                   RenderedCell,
                   headerColumnKey,
                   breakPointHit,

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -14,8 +14,8 @@ import {
 import {
   CellOptions,
   Column,
-  Columns,
   InternalExpansionIconProps,
+  RowEntry,
   RowProps,
   TableProps,
 } from './types';
@@ -31,7 +31,7 @@ const StyledExpansionIconSpan = styled(StyledBaseSpan)`
 export const TableContainer = styled(StyledBaseTable)`
   ${({ reachedMinWidth }: { reachedMinWidth?: boolean }) => {
     const { colors } = useTheme();
-    return `
+    return css`
       width: ${reachedMinWidth ? '100%' : 'auto'};
       background-color: ${colors.background};
       border-collapse: collapse;
@@ -45,7 +45,7 @@ export const TableContainer = styled(StyledBaseTable)`
 export const Header = styled(StyledBaseTR)`
   ${({ columnGap, columnWidths }: RowProps) => {
     const { colors } = useTheme();
-    return `
+    return css`
       display: grid;
       grid-template-columns: ${columnWidths};
       padding: 0em 2em;
@@ -59,7 +59,7 @@ export const Header = styled(StyledBaseTR)`
 `;
 
 export const HeaderCell = styled(StyledBaseTH)`
-  ${({ sortable }: { sortable: boolean }) => `
+  ${({ sortable }: { sortable: boolean }) => css`
     display: flex;
     flex-flow: row;
     cursor: pointer;
@@ -79,7 +79,7 @@ export const HeaderCell = styled(StyledBaseTH)`
 export const Footer = styled(StyledBaseTR)`
   ${({ columnGap, columnWidths }: RowProps) => {
     const { colors } = useTheme();
-    return `
+    return css`
       display: grid;
       grid-template-columns: ${columnWidths};
       padding: 0em 2em;
@@ -108,7 +108,7 @@ export const FooterCell = styled(StyledBaseTH)`
 export const ResponsiveHeaderCell = styled(StyledBaseSpan)`
   ${({ sortable }: { sortable: boolean }) => {
     const { colors } = useTheme();
-    return `
+    return css`
       display: block;
       word-break: break-word;
       hyphens: auto;
@@ -180,7 +180,7 @@ export const Cell = styled(StyledBaseTD)`
 `;
 
 export const SortIcon = styled(Icon)`
-  ${({ direction }: { direction?: boolean | null }) => `
+  ${({ direction }: { direction?: boolean | null }) => css`
     margin-left: 1em;
     fill: white;
     width: 1em;
@@ -295,7 +295,7 @@ const Table = ({
 
   // this builds the string from the columns
   const columnWidths = Object.values(copiedColumns)
-    .map((col: Columns[0]) => {
+    .map((col: Column) => {
       if (col.minTableWidth && width <= col.minTableWidth) {
         return '0px';
       }
@@ -361,15 +361,15 @@ const Table = ({
       );
     } else {
       // Sort the content of each group
-      (data as Array<Array<Columns>>).forEach(() => {
-        data.sort((row1: any, row2: any) =>
+      (data as Array<Array<RowEntry>>).forEach((group) => {
+        group.sort((row1: any, row2: any) =>
           compareEntries(row1[key], row2[key], copiedColumns[key], newDirection),
         );
       });
 
       // Sort the groups
       if (sortGroups) {
-        (data as Array<Array<Columns>>).sort((group1: any, group2: any) =>
+        (data as Array<Array<RowEntry>>).sort((group1: Array<RowEntry>, group2: Array<RowEntry>) =>
           compareEntries(group1[0][key], group2[0][key], copiedColumns[key], newDirection),
         );
       }
@@ -402,7 +402,7 @@ const Table = ({
    * @param {any} options.RenderedCell - The component used as the cell
    * @param {string} options.headerColumnKey - The header column key for the cell
    * @param {boolean} options.breakPointHit - If the breakpoint has been hit for width
-   * @param {Columns} options.row - the data for the row, each cell should be able to the row's data
+   * @param {RowEntry} options.row - the data for the row, each cell should be able to the row's data
    * @param {number} options.index - The index of the cell in the row
    * @param {number} options.indexModifier - Used only when creating cells in a group. Used to account for group labels
    * @param {any} options.CollapseExpandedIcon - Component to be used for the collapse icon. Only used for collapsible group label cells
@@ -482,8 +482,8 @@ const Table = ({
   const createGroups = () => {
     // Generate groupings - Note that we are making shallow copies of the arrays so that we do not
     // modify the props directly since this is an Array of Arrays.
-    return [...(sortedData as Array<Array<Columns>>)].map(
-      (group: Array<Columns>, idx: number) => {
+    return [...(sortedData as Array<Array<RowEntry>>)].map(
+      (group: Array<RowEntry>, idx: number) => {
         const groupLabelIndex: number = group.findIndex(grp => {
           // eslint-disable-next-line @typescript-eslint/ban-ts-comment
           // @ts-ignore
@@ -505,7 +505,7 @@ const Table = ({
         const isCollapsed = !!collapsedGroups[groupLabelDataString + idx];
 
         // Generate the rows for this group
-        const rows = groupCopy.map((row: Columns, index: number) => {
+        const rows = groupCopy.map((row: RowEntry, index: number) => {
           const RenderedRow = row.rowComponent || StyledRow;
           if (index === groupLabelIndex) return null;
 
@@ -622,7 +622,7 @@ const Table = ({
 
     return (
       <tbody>
-        {(sortedData as Array<Columns>).map((row: Columns, index: number) => {
+        {(sortedData as Array<RowEntry>).map((row: RowEntry, index: number) => {
           // map over the rows
           const RenderedRow = row.rowComponent || StyledRow;
           // Rows.map return

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -13,8 +13,8 @@ import {
 } from '../../htmlElements';
 import {
   CellOptions,
-  ColumnType,
-  ColumnTypes,
+  Column,
+  Columns,
   InternalExpansionIconProps,
   RowProps,
   TableProps,
@@ -295,7 +295,7 @@ const Table = ({
 
   // this builds the string from the columns
   const columnWidths = Object.values(copiedColumns)
-    .map((col: ColumnTypes[0]) => {
+    .map((col: Columns[0]) => {
       if (col.minTableWidth && width <= col.minTableWidth) {
         return '0px';
       }
@@ -328,7 +328,7 @@ const Table = ({
    *
    * `direction` is true for ascending, false for descending.
    */
-  const compareEntries = (entry1: any, entry2: any, column: ColumnType, isAscending: boolean) => {
+  const compareEntries = (entry1: any, entry2: any, column: Column, isAscending: boolean) => {
     // If this column has a sort custom sort function, use it.
     if (column && Object.prototype.hasOwnProperty.call(column, 'sortFunction')) {
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -361,7 +361,7 @@ const Table = ({
       );
     } else {
       // Sort the content of each group
-      (data as Array<Array<ColumnTypes>>).forEach(() => {
+      (data as Array<Array<Columns>>).forEach(() => {
         data.sort((row1: any, row2: any) =>
           compareEntries(row1[key], row2[key], copiedColumns[key], newDirection),
         );
@@ -369,7 +369,7 @@ const Table = ({
 
       // Sort the groups
       if (sortGroups) {
-        (data as Array<Array<ColumnTypes>>).sort((group1: any, group2: any) =>
+        (data as Array<Array<Columns>>).sort((group1: any, group2: any) =>
           compareEntries(group1[0][key], group2[0][key], copiedColumns[key], newDirection),
         );
       }
@@ -402,7 +402,7 @@ const Table = ({
    * @param {any} options.RenderedCell - The component used as the cell
    * @param {string} options.headerColumnKey - The header column key for the cell
    * @param {boolean} options.breakPointHit - If the breakpoint has been hit for width
-   * @param {ColumnTypes} options.row - the data for the row, each cell should be able to the row's data
+   * @param {Columns} options.row - the data for the row, each cell should be able to the row's data
    * @param {number} options.index - The index of the cell in the row
    * @param {number} options.indexModifier - Used only when creating cells in a group. Used to account for group labels
    * @param {any} options.CollapseExpandedIcon - Component to be used for the collapse icon. Only used for collapsible group label cells
@@ -482,8 +482,8 @@ const Table = ({
   const createGroups = () => {
     // Generate groupings - Note that we are making shallow copies of the arrays so that we do not
     // modify the props directly since this is an Array of Arrays.
-    return [...(sortedData as Array<Array<ColumnTypes>>)].map(
-      (group: Array<ColumnTypes>, idx: number) => {
+    return [...(sortedData as Array<Array<Columns>>)].map(
+      (group: Array<Columns>, idx: number) => {
         const groupLabelIndex: number = group.findIndex(grp => {
           // eslint-disable-next-line @typescript-eslint/ban-ts-comment
           // @ts-ignore
@@ -505,7 +505,7 @@ const Table = ({
         const isCollapsed = !!collapsedGroups[groupLabelDataString + idx];
 
         // Generate the rows for this group
-        const rows = groupCopy.map((row: ColumnTypes, index: number) => {
+        const rows = groupCopy.map((row: Columns, index: number) => {
           const RenderedRow = row.rowComponent || StyledRow;
           if (index === groupLabelIndex) return null;
 
@@ -622,7 +622,7 @@ const Table = ({
 
     return (
       <tbody>
-        {(sortedData as Array<ColumnTypes>).map((row: ColumnTypes, index: number) => {
+        {(sortedData as Array<Columns>).map((row: Columns, index: number) => {
           // map over the rows
           const RenderedRow = row.rowComponent || StyledRow;
           // Rows.map return

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -116,9 +116,9 @@ export const ResponsiveHeaderCell = styled(StyledBaseSpan)`
       user-select: none;
       padding: 0.5em;
       cursor: pointer;
-      margin-right: .5em;
-      background-color: rgba(0,0,0,0.05);
-      border-radius: .5rem;
+      margin-right: 0.5em;
+      background-color: rgba(0, 0, 0, 0.05);
+      border-radius: 0.5rem;
       ${sortable ? '' : 'pointer-events: none;'}
     `;
   }}
@@ -184,7 +184,7 @@ export const SortIcon = styled(Icon)`
     margin-left: 1em;
     fill: white;
     width: 1em;
-    transition: transform .2s, opacity .5s;
+    transition: transform 0.2s, opacity 0.5s;
     opacity: ${direction === null ? 0 : 1};
     transform: rotate(${direction ? 0 : 180}deg);
   `}
@@ -361,7 +361,7 @@ const Table = ({
       );
     } else {
       // Sort the content of each group
-      (data as Array<Array<RowEntry>>).forEach((group) => {
+      (data as Array<Array<RowEntry>>).forEach(group => {
         group.sort((row1: any, row2: any) =>
           compareEntries(row1[key], row2[key], copiedColumns[key], newDirection),
         );

--- a/src/components/Table/__tests__/__snapshots__/Table.test.tsx.snap
+++ b/src/components/Table/__tests__/__snapshots__/Table.test.tsx.snap
@@ -85,15 +85,16 @@ exports[`Table Shows Table with default props 1`] = `
   -ms-hyphens: auto;
   hyphens: auto;
   width: unset;
+  padding: 0.5em;
 }
 
 .c3 {
   margin-left: 1em;
   fill: white;
   width: 1em;
-  -webkit-transition: -webkit-transform .2s,opacity .5s;
-  -webkit-transition: transform .2s,opacity .5s;
-  transition: transform .2s,opacity .5s;
+  -webkit-transition: -webkit-transform 0.2s,opacity 0.5s;
+  -webkit-transition: transform 0.2s,opacity 0.5s;
+  transition: transform 0.2s,opacity 0.5s;
   opacity: 0;
   -webkit-transform: rotate(180deg);
   -ms-transform: rotate(180deg);
@@ -104,9 +105,9 @@ exports[`Table Shows Table with default props 1`] = `
   margin-left: 1em;
   fill: white;
   width: 1em;
-  -webkit-transition: -webkit-transform .2s,opacity .5s;
-  -webkit-transition: transform .2s,opacity .5s;
-  transition: transform .2s,opacity .5s;
+  -webkit-transition: -webkit-transform 0.2s,opacity 0.5s;
+  -webkit-transition: transform 0.2s,opacity 0.5s;
+  transition: transform 0.2s,opacity 0.5s;
   opacity: 1;
   -webkit-transform: rotate(0deg);
   -ms-transform: rotate(0deg);
@@ -118,7 +119,7 @@ exports[`Table Shows Table with default props 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  padding: 1em 0;
+  padding: 0.5em 0;
 }
 
 <div>

--- a/src/components/Table/__tests__/__snapshots__/Table.test.tsx.snap
+++ b/src/components/Table/__tests__/__snapshots__/Table.test.tsx.snap
@@ -47,7 +47,7 @@ exports[`Table Shows Table with default props 1`] = `
   display: grid;
   grid-template-columns: 1fr 1fr 1fr;
   padding: 0em 2em;
-  row-gap: .5em;
+  row-gap: 0.5em;
   -webkit-column-gap: 1em;
   column-gap: 1em;
   position: relative;
@@ -68,18 +68,17 @@ exports[`Table Shows Table with default props 1`] = `
   height: 100%;
   background-color: rgba(0,0,0,0.2);
   opacity: 0;
-  -webkit-transition: opacity .3s;
-  transition: opacity .3s;
+  -webkit-transition: opacity 0.3s;
+  transition: opacity 0.3s;
   pointer-events: none;
 }
 
 .c5:hover:before {
-  opacity: .3;
+  opacity: 0.3;
 }
 
-.c6 {
+.c7 {
   display: block;
-  padding: 1em 0;
   word-break: break-word;
   -webkit-hyphens: auto;
   -moz-hyphens: auto;
@@ -112,6 +111,14 @@ exports[`Table Shows Table with default props 1`] = `
   -webkit-transform: rotate(0deg);
   -ms-transform: rotate(0deg);
   transform: rotate(0deg);
+}
+
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  padding: 1em 0;
 }
 
 <div>
@@ -174,59 +181,95 @@ exports[`Table Shows Table with default props 1`] = `
       <tr
         class=" c5"
       >
-        <td
+        <div
           class=" c6"
         >
-          Apple
-        </td>
-        <td
+          <td
+            class=" c7"
+          >
+            Apple
+          </td>
+        </div>
+        <div
           class=" c6"
         >
-          Red
-        </td>
-        <td
+          <td
+            class=" c7"
+          >
+            Red
+          </td>
+        </div>
+        <div
           class=" c6"
         >
-          1
-        </td>
+          <td
+            class=" c7"
+          >
+            1
+          </td>
+        </div>
       </tr>
       <tr
         class=" c5"
       >
-        <td
+        <div
           class=" c6"
         >
-          Kiwi
-        </td>
-        <td
+          <td
+            class=" c7"
+          >
+            Kiwi
+          </td>
+        </div>
+        <div
           class=" c6"
         >
-          Brown
-        </td>
-        <td
+          <td
+            class=" c7"
+          >
+            Brown
+          </td>
+        </div>
+        <div
           class=" c6"
         >
-          2
-        </td>
+          <td
+            class=" c7"
+          >
+            2
+          </td>
+        </div>
       </tr>
       <tr
         class=" c5"
       >
-        <td
+        <div
           class=" c6"
         >
-          Banana
-        </td>
-        <td
+          <td
+            class=" c7"
+          >
+            Banana
+          </td>
+        </div>
+        <div
           class=" c6"
         >
-          Yellow
-        </td>
-        <td
+          <td
+            class=" c7"
+          >
+            Yellow
+          </td>
+        </div>
+        <div
           class=" c6"
         >
-          3
-        </td>
+          <td
+            class=" c7"
+          >
+            3
+          </td>
+        </div>
       </tr>
     </tbody>
     <tfoot />

--- a/src/components/Table/__tests__/__snapshots__/Table.test.tsx.snap
+++ b/src/components/Table/__tests__/__snapshots__/Table.test.tsx.snap
@@ -85,7 +85,7 @@ exports[`Table Shows Table with default props 1`] = `
   -ms-hyphens: auto;
   hyphens: auto;
   width: unset;
-  padding: 0.5em;
+  padding: 0.5em 0;
 }
 
 .c3 {

--- a/src/components/Table/types.ts
+++ b/src/components/Table/types.ts
@@ -1,4 +1,4 @@
-import React, { Component, FunctionComponent, MouseEventHandler, ReactNode } from 'react';
+import React, { FunctionComponent, MouseEventHandler, ReactNode } from 'react';
 import { SubcomponentPropsType, StyledSubcomponentType } from '../commonTypes';
 
 export type ExpansionIconProps = {
@@ -23,13 +23,11 @@ export interface Column {
   footerContent?: ReactNode;
   sortFunction?: (item1: any, item2: any) => boolean;
   isGroupLabel?: boolean;
-  cellComponent?: ComponentBuilder;
-  rowComponent?: ComponentBuilder;
-  headerCellComponent?: ComponentBuilder;
-  groupCellComponent?: ComponentBuilder;
+  cellComponent?: StyledSubcomponentType;
+  rowComponent?: StyledSubcomponentType;
+  headerCellComponent?: StyledSubcomponentType;
+  groupCellComponent?: StyledSubcomponentType;
 }
-
-type ComponentBuilder = StyledSubcomponentType | ((props: any) => JSX.Element) | React.FC;
 
 /**
  * @deprecated Use `Columns`.
@@ -100,7 +98,7 @@ export type RowProps = {
 };
 
 export type CellOptions = {
-  RenderedCell: ComponentBuilder;
+  RenderedCell: StyledSubcomponentType;
   headerColumnKey: string;
   breakPointHit: boolean;
   row: RowEntry;

--- a/src/components/Table/types.ts
+++ b/src/components/Table/types.ts
@@ -11,30 +11,42 @@ export type InternalExpansionIconProps = {
   onClick: MouseEventHandler;
 };
 
-export interface columnTypes {
-  [index: string]: {
-    name?: string;
-    width?: string;
-    minTableWidth?: number;
-    sortable?: boolean;
-    footerContent?: ReactNode;
-    sortFunction?: (item1: any, item2: any) => boolean;
-    isGroupLabel?: boolean;
-    cellComponent?: StyledSubcomponentType;
-    rowComponent?: StyledSubcomponentType;
-    headerCellComponent?: StyledSubcomponentType;
-    groupCellComponent?: StyledSubcomponentType;
-  };
+export interface ColumnTypes {
+  [index: string]: ColumnType;
 }
+
+export interface ColumnType {
+  name?: string;
+  width?: string;
+  minTableWidth?: number;
+  sortable?: boolean;
+  footerContent?: ReactNode;
+  sortFunction?: (item1: any, item2: any) => boolean;
+  isGroupLabel?: boolean;
+  cellComponent?: ComponentBuilder;
+  rowComponent?: ComponentBuilder;
+  headerCellComponent?: ComponentBuilder;
+  groupCellComponent?: ComponentBuilder;
+}
+
+type ComponentBuilder = StyledSubcomponentType | ((props: any) => JSX.Element) | React.FC;
+
+/**
+ * @deprecated Use `ColumnTypes`.
+ */
+export type columnTypes = ColumnTypes;
 
 export type TableProps = {
   areGroupsCollapsible?: boolean;
   columnGap?: string;
-  columns: columnTypes;
-  data?: columnTypes[] | Array<Array<columnTypes>>;
+  columns: ColumnTypes;
+  data?: ColumnTypes[] | Array<Array<ColumnTypes>>;
   defaultSort?: [string, boolean]; // key, direction
   groupHeaderPosition?: 'above' | 'below';
   expansionIconComponent?: FunctionComponent<InternalExpansionIconProps>;
+  /**
+   * The width of the Table (in px) at which the Table collapses into vertical mode.
+   */
   minWidthBreakpoint?: number;
   sortGroups?: boolean;
 
@@ -43,22 +55,40 @@ export type TableProps = {
   StyledGroupLabelRow?: StyledSubcomponentType;
   StyledHeader?: StyledSubcomponentType;
   StyledHeaderCell?: StyledSubcomponentType;
+  /**
+   * If in responsive mode (width < `minWidthBreakpoint`), the `StyledResponsiveHeaderCell` will appear next to the
+   * `StyledCell`. By default, it displays the `name` of the column. This component is not displayed if not in responsive
+   * mode, or if the column has no `name`.
+   */
+  StyledResponsiveHeaderCell?: StyledSubcomponentType;
   StyledRow?: StyledSubcomponentType;
   StyledFooter?: StyledSubcomponentType;
   StyledFooterCell?: StyledSubcomponentType;
+  /**
+   * If in responsive mode (width < `minWidthBreakpoint`), the `CellContainer` contains the `StyledCell`
+   * and the `StyledResponsiveHeaderCellA `CellContainer` contains the `StyledCell`, as well as the `StyledResponsiveHeaderCell` for each cell
+   * if width is less than `minWidthBreakpoint`. If width is greater than `minWidthBreakpoint`, then the `CellContainer`
+   * only wraps the `StyledCell`.
+   */
+  StyledCellContainer?: StyledSubcomponentType;
 
   cellProps?: SubcomponentPropsType;
   containerProps?: SubcomponentPropsType;
   groupLabelRowProps?: SubcomponentPropsType;
   headerProps?: SubcomponentPropsType;
   headerCellProps?: SubcomponentPropsType;
+  responsiveHeaderCellProps?: SubcomponentPropsType;
   rowProps?: SubcomponentPropsType;
 
   containerRef?: React.RefObject<HTMLTableElement>;
   groupLabelRowRef?: React.RefObject<HTMLElement>;
   headerRef?: React.RefObject<HTMLTableRowElement>;
-  headerCellRef?: React.RefObject<HTMLTableHeaderCellElement>;
+  /**
+   * @deprecated Do not use.
+   */
+  headerCellRef?: React.RefObject<HTMLTableCellElement>;
 };
+
 export type RowProps = {
   columnGap: string;
   columnWidths: string;
@@ -66,11 +96,12 @@ export type RowProps = {
   reachedMinWidth?: boolean;
   isCollapsed?: boolean;
 };
+
 export type CellOptions = {
-  RenderedCell: any;
+  RenderedCell: StyledSubcomponentType;
   headerColumnKey: string;
   breakPointHit: boolean;
-  row: columnTypes;
+  row: ColumnTypes;
   index: number;
   indexModifier?: number;
   CollapseExpandedIcon?: any;

--- a/src/components/Table/types.ts
+++ b/src/components/Table/types.ts
@@ -12,7 +12,7 @@ export type InternalExpansionIconProps = {
 };
 
 /** Map between column key strings and column properties. */
-export type Columns = Record<string, Column>
+export type Columns = Record<string, Column>;
 
 /** The properties that can be defined for a single column. */
 export interface Column {

--- a/src/components/Table/types.ts
+++ b/src/components/Table/types.ts
@@ -98,7 +98,7 @@ export type RowProps = {
 };
 
 export type CellOptions = {
-  RenderedCell: StyledSubcomponentType;
+  RenderedCell: ComponentBuilder;
   headerColumnKey: string;
   breakPointHit: boolean;
   row: ColumnTypes;

--- a/src/components/Table/types.ts
+++ b/src/components/Table/types.ts
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, MouseEventHandler, ReactNode } from 'react';
+import React, { Component, FunctionComponent, MouseEventHandler, ReactNode } from 'react';
 import { SubcomponentPropsType, StyledSubcomponentType } from '../commonTypes';
 
 export type ExpansionIconProps = {
@@ -32,7 +32,7 @@ export interface Column {
 type ComponentBuilder = StyledSubcomponentType | ((props: any) => JSX.Element) | React.FC;
 
 /**
- * @deprecated Use `ColumnTypes`.
+ * @deprecated Use `Columns`.
  */
 export type columnTypes = Columns;
 
@@ -43,7 +43,7 @@ export type TableProps = {
   areGroupsCollapsible?: boolean;
   columnGap?: string;
   columns: Columns;
-  data?: RowEntry[] | Array<Array<RowEntry>>;
+  data?: Array<RowEntry> | Array<Array<RowEntry>>;
   defaultSort?: [string, boolean]; // key, direction
   groupHeaderPosition?: 'above' | 'below';
   expansionIconComponent?: FunctionComponent<InternalExpansionIconProps>;
@@ -59,9 +59,8 @@ export type TableProps = {
   StyledHeader?: StyledSubcomponentType;
   StyledHeaderCell?: StyledSubcomponentType;
   /**
-   * If in responsive mode (width < `minWidthBreakpoint`), the `StyledResponsiveHeaderCell` will appear next to the
-   * `StyledCell`. By default, it displays the `name` of the column. This component is not displayed if not in responsive
-   * mode, or if the column has no `name`.
+   * Header cells used when the Table is in condensed view
+   * based on `minWidthBreakpoint`
    */
   StyledResponsiveHeaderCell?: StyledSubcomponentType;
   StyledRow?: StyledSubcomponentType;

--- a/src/components/Table/types.ts
+++ b/src/components/Table/types.ts
@@ -11,10 +11,10 @@ export type InternalExpansionIconProps = {
   onClick: MouseEventHandler;
 };
 
-export interface Columns {
-  [index: string]: Column;
-}
+/** Map between column key strings and column properties. */
+export type Columns = Record<string, Column>
 
+/** The properties that can be defined for a single column. */
 export interface Column {
   name?: string;
   width?: string;
@@ -36,11 +36,14 @@ type ComponentBuilder = StyledSubcomponentType | ((props: any) => JSX.Element) |
  */
 export type columnTypes = Columns;
 
+/** The data for a single row. */
+export type RowEntry = Record<string, any>;
+
 export type TableProps = {
   areGroupsCollapsible?: boolean;
   columnGap?: string;
   columns: Columns;
-  data?: Columns[] | Array<Array<Columns>>;
+  data?: RowEntry[] | Array<Array<RowEntry>>;
   defaultSort?: [string, boolean]; // key, direction
   groupHeaderPosition?: 'above' | 'below';
   expansionIconComponent?: FunctionComponent<InternalExpansionIconProps>;
@@ -101,7 +104,7 @@ export type CellOptions = {
   RenderedCell: ComponentBuilder;
   headerColumnKey: string;
   breakPointHit: boolean;
-  row: Columns;
+  row: RowEntry;
   index: number;
   indexModifier?: number;
   CollapseExpandedIcon?: any;

--- a/src/components/Table/types.ts
+++ b/src/components/Table/types.ts
@@ -11,11 +11,11 @@ export type InternalExpansionIconProps = {
   onClick: MouseEventHandler;
 };
 
-export interface ColumnTypes {
-  [index: string]: ColumnType;
+export interface Columns {
+  [index: string]: Column;
 }
 
-export interface ColumnType {
+export interface Column {
   name?: string;
   width?: string;
   minTableWidth?: number;
@@ -34,13 +34,13 @@ type ComponentBuilder = StyledSubcomponentType | ((props: any) => JSX.Element) |
 /**
  * @deprecated Use `ColumnTypes`.
  */
-export type columnTypes = ColumnTypes;
+export type columnTypes = Columns;
 
 export type TableProps = {
   areGroupsCollapsible?: boolean;
   columnGap?: string;
-  columns: ColumnTypes;
-  data?: ColumnTypes[] | Array<Array<ColumnTypes>>;
+  columns: Columns;
+  data?: Columns[] | Array<Array<Columns>>;
   defaultSort?: [string, boolean]; // key, direction
   groupHeaderPosition?: 'above' | 'below';
   expansionIconComponent?: FunctionComponent<InternalExpansionIconProps>;
@@ -101,7 +101,7 @@ export type CellOptions = {
   RenderedCell: ComponentBuilder;
   headerColumnKey: string;
   breakPointHit: boolean;
-  row: ColumnTypes;
+  row: Columns;
   index: number;
   indexModifier?: number;
   CollapseExpandedIcon?: any;

--- a/src/components/commonTypes.ts
+++ b/src/components/commonTypes.ts
@@ -1,9 +1,7 @@
-import { StyledComponentBase } from 'styled-components';
-
 export type SubcomponentPropsType = Record<string, unknown>;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/ban-types
 export type StyledSubcomponentType<P = any, O extends object = {}> =
-  | (string & StyledComponentBase<any, SubcomponentPropsType, O>)
+  | string
   | ((props: P) => JSX.Element)
   | React.FC<P>;

--- a/src/components/commonTypes.ts
+++ b/src/components/commonTypes.ts
@@ -1,5 +1,5 @@
 import { StyledComponentBase } from 'styled-components';
 
 export type SubcomponentPropsType = Record<string, unknown>;
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type StyledSubcomponentType = string & StyledComponentBase<any, SubcomponentPropsType>;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/ban-types
+export type StyledSubcomponentType<O extends object = {}>= (string & StyledComponentBase<any, SubcomponentPropsType, O>) | ((props: any) => JSX.Element) | React.FC;

--- a/src/components/commonTypes.ts
+++ b/src/components/commonTypes.ts
@@ -1,6 +1,7 @@
 import { StyledComponentBase } from 'styled-components';
 
 export type SubcomponentPropsType = Record<string, unknown>;
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/ban-types
 export type StyledSubcomponentType<O extends object = {}> =
   | (string & StyledComponentBase<any, SubcomponentPropsType, O>)

--- a/src/components/commonTypes.ts
+++ b/src/components/commonTypes.ts
@@ -1,7 +1,9 @@
+import { StyledComponentBase } from 'styled-components';
+
 export type SubcomponentPropsType = Record<string, unknown>;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/ban-types
-export type StyledSubcomponentType<P = any, O extends object = {}> =
-  | string
+export type StyledSubcomponentType<P = any> =
+  | StyledComponentBase<any, any>
   | ((props: P) => JSX.Element)
   | React.FC<P>;

--- a/src/components/commonTypes.ts
+++ b/src/components/commonTypes.ts
@@ -1,5 +1,9 @@
 import { StyledComponentBase } from 'styled-components';
 
 export type SubcomponentPropsType = Record<string, unknown>;
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type StyledSubcomponentType = string & StyledComponentBase<any, SubcomponentPropsType>;
+export type StyledSubcomponentType = React.FC | ((props: any) => JSX.Element) | StyledComponent;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type StyledComponent = string & StyledComponentBase<any, SubcomponentPropsType>;

--- a/src/components/commonTypes.ts
+++ b/src/components/commonTypes.ts
@@ -2,4 +2,7 @@ import { StyledComponentBase } from 'styled-components';
 
 export type SubcomponentPropsType = Record<string, unknown>;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/ban-types
-export type StyledSubcomponentType<O extends object = {}>= (string & StyledComponentBase<any, SubcomponentPropsType, O>) | ((props: any) => JSX.Element) | React.FC;
+export type StyledSubcomponentType<O extends object = {}> =
+  | (string & StyledComponentBase<any, SubcomponentPropsType, O>)
+  | ((props: any) => JSX.Element)
+  | React.FC;

--- a/src/components/commonTypes.ts
+++ b/src/components/commonTypes.ts
@@ -3,7 +3,7 @@ import { StyledComponentBase } from 'styled-components';
 export type SubcomponentPropsType = Record<string, unknown>;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/ban-types
-export type StyledSubcomponentType<O extends object = {}> =
+export type StyledSubcomponentType<P = any, O extends object = {}> =
   | (string & StyledComponentBase<any, SubcomponentPropsType, O>)
-  | ((props: any) => JSX.Element)
-  | React.FC;
+  | ((props: P) => JSX.Element)
+  | React.FC<P>;

--- a/src/components/commonTypes.ts
+++ b/src/components/commonTypes.ts
@@ -1,9 +1,5 @@
 import { StyledComponentBase } from 'styled-components';
 
 export type SubcomponentPropsType = Record<string, unknown>;
-
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type StyledSubcomponentType = React.FC | ((props: any) => JSX.Element) | StyledComponent;
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type StyledComponent = string & StyledComponentBase<any, SubcomponentPropsType>;
+export type StyledSubcomponentType = string & StyledComponentBase<any, SubcomponentPropsType>;


### PR DESCRIPTION
**This PR accomplishes the following:** 
- Adds type support for custom component builders with props for columns in the `Columns` type, for things like cellComponent, headerCellComponent, etc, while retaining support for StyledComponents (see `ComponentBuilder`)
- Fixes group headers appearance in responsive view
- Makes custom sortFunctions functional in both directions, and extracts reusable comparison code into the `compareEntries` function, fixes group sorting
- Fixes sorting on the Table storyboard
- Fixes responsive view 
- Fixes passing in of rowProps StyledRow for non-grouped Table's
- Allows for styling of the ResponsiveHeaderCell, and wraps cell in CellContainer (which contains both the ResponsiveHeaderCell if in responsive mode, and the Cell).
- Change type of table `data` to `RowEntry[]`. Originally was `ColumnTypes`, which has no overlap with expected input. More clear typing.