### PR TITLE
Improve range slider callbacks

### DIFF
--- a/src/components/RangeSlider/RangeSlider.stories.tsx
+++ b/src/components/RangeSlider/RangeSlider.stories.tsx
@@ -103,9 +103,9 @@ export const Default: Story<DefaultProps> = ({
         min={min}
         max={max}
         debounceInterval={debounceInterval}
-        onDrag={(newVal: number) => {
+        onChange={(newVal: number) => {
           setVal(Math.round(newVal));
-          action('onDrag')(newVal);
+          action('onChange')(newVal);
         }}
         axisLock={axisLock}
         values={[
@@ -170,9 +170,9 @@ export const Rating: Story<RatingProps> = ({
         min={min}
         max={max}
         debounceInterval={debounceInterval}
-        onDrag={(newVal: number) => {
+        onChange={newVal => {
           setVal(Math.round(newVal));
-          action('onDrag')(newVal);
+          action('onChange')(newVal);
         }}
         axisLock={axisLock}
         values={[
@@ -195,7 +195,7 @@ Rating.args = {
   springOnRelease: true,
   min: 0,
   max: 5,
-  debounceInterval: 8,
+  debounceInterval: 100,
   axisLock: 'x',
 };
 
@@ -272,9 +272,10 @@ export const ColorPicker: Story<ColorPickerProps> = ({
           showSelectedRange={false}
           min={0}
           max={360}
-          onDrag={(val: number) => {
+          debounceInterval={100}
+          onChange={(val: number) => {
             setHue(Math.round(val));
-            action('onDrag hue')(val);
+            action('onChange hue')(val);
           }}
           values={[
             {
@@ -299,9 +300,9 @@ export const ColorPicker: Story<ColorPickerProps> = ({
           ))}
           min={0}
           max={100}
-          onDrag={(val: number) => {
+          onChange={(val: number) => {
             setSat(Math.round(val));
-            action('onDrag saturation')(val);
+            action('onChange saturation')(val);
           }}
           showDomainLabels={false}
           showSelectedRange={false}
@@ -330,9 +331,9 @@ export const ColorPicker: Story<ColorPickerProps> = ({
           ))}
           min={0}
           max={100}
-          onDrag={(val: number) => {
+          onChange={(val: number) => {
             setLight(Math.round(val));
-            action('onDrag light')(val);
+            action('onChange light')(val);
           }}
           showDomainLabels={false}
           showSelectedRange={false}

--- a/src/components/RangeSlider/RangeSlider.stories.tsx
+++ b/src/components/RangeSlider/RangeSlider.stories.tsx
@@ -8,7 +8,7 @@ import { withFoundryContext } from '../../../.storybook/decorators';
 import fonts from '../../enums/fonts';
 import colors from '../../enums/colors';
 import RangeSlider, { SlideRail } from './RangeSlider';
-import { RangeSliderProps } from './types';
+import { RangeSliderProps, ValueProp } from './types';
 import Card from '../Card';
 
 const Row = styled.div`
@@ -72,7 +72,6 @@ export const Default: Story<DefaultProps> = ({
   springOnRelease,
   min,
   max,
-  debounceInterval,
   axisLock,
 }: DefaultProps) => {
   const [val, setVal] = useState(value);
@@ -82,7 +81,7 @@ export const Default: Story<DefaultProps> = ({
   }, [value]);
 
   const markersSelection = markers;
-  const markersArray = [];
+  const markersArray: Array<number | ValueProp> = [];
   if (markersSelection === 'all values') {
     for (let i = min; i <= max; i++) {
       markersArray.push(markerLabels ? { value: i, label: `${i}` } : i);
@@ -102,11 +101,7 @@ export const Default: Story<DefaultProps> = ({
         springOnRelease={springOnRelease}
         min={min}
         max={max}
-        debounceInterval={debounceInterval}
-        onChange={(newVal: number) => {
-          setVal(Math.round(newVal));
-          action('onChange')(newVal);
-        }}
+        onChange={newVal => setVal(Math.round(newVal))}
         axisLock={axisLock}
         values={[
           {
@@ -131,7 +126,6 @@ Default.args = {
   showSelectedRange: true,
   motionBlur: false,
   springOnRelease: true,
-  debounceInterval: 8,
   axisLock: 'x',
 };
 
@@ -148,7 +142,6 @@ export const Rating: Story<RatingProps> = ({
   springOnRelease,
   min,
   max,
-  debounceInterval,
   axisLock,
 }: RatingProps) => {
   const [val, setVal] = useState(value);
@@ -169,7 +162,6 @@ export const Rating: Story<RatingProps> = ({
         springOnRelease={springOnRelease}
         min={min}
         max={max}
-        debounceInterval={debounceInterval}
         onChange={newVal => {
           setVal(Math.round(newVal));
           action('onChange')(newVal);
@@ -195,7 +187,6 @@ Rating.args = {
   springOnRelease: true,
   min: 0,
   max: 5,
-  debounceInterval: 100,
   axisLock: 'x',
 };
 
@@ -272,7 +263,6 @@ export const ColorPicker: Story<ColorPickerProps> = ({
           showSelectedRange={false}
           min={0}
           max={360}
-          debounceInterval={100}
           onChange={(val: number) => {
             setHue(Math.round(val));
             action('onChange hue')(val);
@@ -376,14 +366,6 @@ export default {
         type: 'range',
         min: -10,
         max: 10,
-        step: 1,
-      },
-    },
-    debounceInterval: {
-      control: {
-        type: 'range',
-        min: 0,
-        max: 100,
         step: 1,
       },
     },

--- a/src/components/RangeSlider/RangeSlider.tsx
+++ b/src/components/RangeSlider/RangeSlider.tsx
@@ -67,7 +67,7 @@ export const Container = styled.div`
 `;
 
 export const DragHandle = styled(a.div)`
-  ${({ beingDragged = false, color }: HandleProps) => {
+  ${({ $beingDragged = false, color }: HandleProps) => {
     const { colors } = useTheme();
     const handleColor = color || colors.primary;
     return `
@@ -87,7 +87,7 @@ export const DragHandle = styled(a.div)`
 
       filter: url(#blur);
 
-      cursor: ${beingDragged ? 'grabbing' : 'grab'};
+      cursor: ${$beingDragged ? 'grabbing' : 'grab'};
       z-index: 2;
     `;
   }}
@@ -254,7 +254,7 @@ export const RangeSlider = ({
     }
   }
 
-  const { colors } = useTheme();
+  // const { colors } = useTheme();
   const { prefersReducedMotion } = useAccessibilityPreferences();
   const hasHandleLabels = useRef(false);
   const initializing = useRef(true);
@@ -273,21 +273,21 @@ export const RangeSlider = ({
     () =>
       values?.map((val: number | ValueProp) => {
         if (typeof val === 'number') {
-          return { value: val, label: val, color: colors.primary };
+          return { value: val, label: undefined, color: undefined };
         }
         if (Object.prototype.hasOwnProperty.call(val, 'label')) {
           hasHandleLabels.current = true;
         }
         return val;
       }) ?? [],
-    [values, colors],
+    [values],
   );
 
   // Convert `markers` prop from `number[] | ValueProp[]` into strictly `ValueProp[]`
   const processedMarkers: Array<ValueProp> =
     markers?.map((val: number | ValueProp) => {
       if (typeof val === 'number') {
-        return { value: val, label: val, color: colors.primary };
+        return { value: val, label: undefined, color: undefined };
       }
       return val;
     }) ?? [];
@@ -344,7 +344,7 @@ export const RangeSlider = ({
   });
 
   // get the x offset and an animation setter function
-  const [{ x, y }, set] = useSpring(() => ({
+  const [{ x, y }, springRef] = useSpring(() => ({
     to: { x: pixelPositions[0], y: 0 },
     friction: 13,
     tension: 100,
@@ -409,7 +409,7 @@ export const RangeSlider = ({
 
       setDraggedHandle(down ? 0 : -1);
       handleDrag(valueBuffer.current);
-      set({
+      springRef.start({
         x: down ? deltaX : pixelPositions[0],
         y: down ? deltaY : 0,
 
@@ -432,7 +432,7 @@ export const RangeSlider = ({
   );
 
   useEffect(() => {
-    set({
+    springRef.start({
       x: pixelPositions[0],
       y: 0,
 
@@ -445,7 +445,7 @@ export const RangeSlider = ({
         initializing.current = false;
       },
     });
-  }, [pixelPositions, set, springOnRelease, prefersReducedMotion]);
+  }, [pixelPositions, springRef, springOnRelease, prefersReducedMotion]);
 
   return (
     <StyledContainer
@@ -491,7 +491,7 @@ export const RangeSlider = ({
           // eslint-disable-next-line react/jsx-props-no-spreading
           {...bind()}
           draggable={false}
-          beingDragged={i === draggedHandle}
+          $beingDragged={i === draggedHandle}
           style={{ x, y }}
           color={color}
           // eslint-disable-next-line react/no-array-index-key

--- a/src/components/RangeSlider/RangeSlider.tsx
+++ b/src/components/RangeSlider/RangeSlider.tsx
@@ -271,6 +271,8 @@ export const RangeSlider = ({
   // Convert `values` prop from number[] | ValueProp[] into strictly ValueProp[]
   const processedValues: Array<ValueProp> = useMemo(
     () =>
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore This expression is not callable.
       values?.map((val: number | ValueProp) => {
         if (typeof val === 'number') {
           return { value: val, label: undefined, color: undefined };
@@ -285,6 +287,8 @@ export const RangeSlider = ({
 
   // Convert `markers` prop from `number[] | ValueProp[]` into strictly `ValueProp[]`
   const processedMarkers: Array<ValueProp> =
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore This expression is not callable.
     markers?.map((val: number | ValueProp) => {
       if (typeof val === 'number') {
         return { value: val, label: undefined, color: undefined };

--- a/src/components/RangeSlider/__tests__/RangeSlider.test.tsx
+++ b/src/components/RangeSlider/__tests__/RangeSlider.test.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import { render, fireEvent, waitFor, configure } from '@testing-library/react';
-import Icon from '@mdi/react';
-import RangeSlider from '../RangeSlider';
 import { axe, toHaveNoViolations } from 'jest-axe';
+import RangeSlider from '../RangeSlider';
 
 expect.extend(toHaveNoViolations);
 configure({ testIdAttribute: 'data-test-id' });

--- a/src/components/RangeSlider/types.ts
+++ b/src/components/RangeSlider/types.ts
@@ -64,9 +64,15 @@ export type RangeSliderProps = {
 
   motionBlur?: boolean;
   springOnRelease?: boolean;
+  /** Debounce interval (in ms) before calling `onDebounceChange`. */
   debounceInterval?: number;
   axisLock?: 'x' | 'y' | '';
+  /** @deprecated use onChange or onDebounceChange instead. */
   onDrag?: (val: number) => void;
+  /** Called immediately as value slider's selection, regardless of `debounceInterval`. */
+  onChange?: (val: number) => void;
+  /** Called after `debounceInterval` as slider's selection changes. */
+  onDebounceChange?: (val: number) => void;
   disabled?: boolean;
   min: number;
   max: number;

--- a/src/components/RangeSlider/types.ts
+++ b/src/components/RangeSlider/types.ts
@@ -16,7 +16,7 @@ export type ContainerProps = {
 };
 
 export type HandleProps = {
-  beingDragged?: boolean;
+  $beingDragged?: boolean;
   color: string;
 };
 


### PR DESCRIPTION
In response to issue #441

This PR adds to RangeSlider:
 - onChange callback, called immediately on every value change to slider
 - onDebounceChange callback, called after debounceInterval 
 - Deprecates onDrag, but maintains its functionality

Other changes to RangeSlider:
 - Change DragHandle's beingDragged to $beingDragged (transient StyledComponent prop to suppress DOM warning that beingDragged is an unknown attribute) 
 - Improves typing of processedMarkers and processedValues to remove type errors and redundant code