### PR TITLE
Implemented isReadOnly prop for RangeSlider component

### DIFF
--- a/src/components/RangeSlider/RangeSlider.stories.tsx
+++ b/src/components/RangeSlider/RangeSlider.stories.tsx
@@ -74,7 +74,7 @@ export const Default: Story<DefaultProps> = ({
   max,
   debounceInterval,
   axisLock,
-  maintainColorWhenDisabled,
+  isReadOnly,
 }: DefaultProps) => {
   const [val, setVal] = useState(value);
 
@@ -97,7 +97,7 @@ export const Default: Story<DefaultProps> = ({
     <Row>
       <RangeSlider
         disabled={disabled}
-        maintainColorWhenDisabled={maintainColorWhenDisabled}
+        isReadOnly={isReadOnly}
         showDomainLabels={showDomainLabels}
         showSelectedRange={showSelectedRange}
         motionBlur={motionBlur}
@@ -128,7 +128,7 @@ Default.args = {
   markers: 'none',
   'use marker labels': false,
   disabled: false,
-  maintainColorWhenDisabled: false,
+  isReadOnly: false,
   showDomainLabels: false,
   showHandleLabels: true,
   showSelectedRange: true,

--- a/src/components/RangeSlider/RangeSlider.stories.tsx
+++ b/src/components/RangeSlider/RangeSlider.stories.tsx
@@ -74,7 +74,7 @@ export const Default: Story<DefaultProps> = ({
   max,
   debounceInterval,
   axisLock,
-  readOnly,
+  readonly,
 }: DefaultProps) => {
   const [val, setVal] = useState(value);
 
@@ -97,7 +97,7 @@ export const Default: Story<DefaultProps> = ({
     <Row>
       <RangeSlider
         disabled={disabled}
-        readOnly={readOnly}
+        readonly={readonly}
         showDomainLabels={showDomainLabels}
         showSelectedRange={showSelectedRange}
         motionBlur={motionBlur}
@@ -128,7 +128,7 @@ Default.args = {
   markers: 'none',
   'use marker labels': false,
   disabled: false,
-  readOnly: false,
+  readonly: false,
   showDomainLabels: false,
   showHandleLabels: true,
   showSelectedRange: true,

--- a/src/components/RangeSlider/RangeSlider.stories.tsx
+++ b/src/components/RangeSlider/RangeSlider.stories.tsx
@@ -74,7 +74,7 @@ export const Default: Story<DefaultProps> = ({
   max,
   debounceInterval,
   axisLock,
-  isReadOnly,
+  readOnly,
 }: DefaultProps) => {
   const [val, setVal] = useState(value);
 
@@ -97,7 +97,7 @@ export const Default: Story<DefaultProps> = ({
     <Row>
       <RangeSlider
         disabled={disabled}
-        isReadOnly={isReadOnly}
+        readOnly={readOnly}
         showDomainLabels={showDomainLabels}
         showSelectedRange={showSelectedRange}
         motionBlur={motionBlur}
@@ -128,7 +128,7 @@ Default.args = {
   markers: 'none',
   'use marker labels': false,
   disabled: false,
-  isReadOnly: false,
+  readOnly: false,
   showDomainLabels: false,
   showHandleLabels: true,
   showSelectedRange: true,

--- a/src/components/RangeSlider/RangeSlider.stories.tsx
+++ b/src/components/RangeSlider/RangeSlider.stories.tsx
@@ -74,6 +74,7 @@ export const Default: Story<DefaultProps> = ({
   max,
   debounceInterval,
   axisLock,
+  maintainColorWhenDisabled,
 }: DefaultProps) => {
   const [val, setVal] = useState(value);
 
@@ -96,6 +97,7 @@ export const Default: Story<DefaultProps> = ({
     <Row>
       <RangeSlider
         disabled={disabled}
+        maintainColorWhenDisabled={maintainColorWhenDisabled}
         showDomainLabels={showDomainLabels}
         showSelectedRange={showSelectedRange}
         motionBlur={motionBlur}
@@ -126,6 +128,7 @@ Default.args = {
   markers: 'none',
   'use marker labels': false,
   disabled: false,
+  maintainColorWhenDisabled: false,
   showDomainLabels: false,
   showHandleLabels: true,
   showSelectedRange: true,

--- a/src/components/RangeSlider/RangeSlider.tsx
+++ b/src/components/RangeSlider/RangeSlider.tsx
@@ -29,7 +29,6 @@ export const Container = styled.div`
     hasHandleLabels,
     disabled,
     beingDragged = false,
-    isReadOnly,
   }: ContainerProps) => `
     position: relative;
     height: 1rem;
@@ -51,12 +50,7 @@ export const Container = styled.div`
         : ''
     }
 
-    ${
-      isReadOnly
-        ? `
-        pointer-events: none;`
-        : ''
-    }
+    
 
     ${
       showDomainLabels
@@ -79,7 +73,7 @@ export const Container = styled.div`
 `;
 
 export const DragHandle = styled(a.div)`
-  ${({ beingDragged = false, color }: HandleProps) => {
+  ${({ beingDragged = false, color, isReadOnly }: HandleProps) => {
     const { colors } = useTheme();
     const handleColor = color || colors.primary;
     return `
@@ -96,10 +90,9 @@ export const DragHandle = styled(a.div)`
       border-radius: 50%;
       
       touch-action: none;
-
       filter: url(#blur);
-
       cursor: ${beingDragged ? 'grabbing' : 'grab'};
+      cursor: ${isReadOnly ? 'default' : ''};
       z-index: 2;
     `;
   }}
@@ -314,7 +307,7 @@ export const RangeSlider = ({
 
   const handleDrag = useCallback(
     (newVal: number) =>
-      handleEventWithAnalytics(
+      !isReadOnly && handleEventWithAnalytics(
         'RangeSlider',
         () => {
           onDrag(newVal);
@@ -407,7 +400,6 @@ export const RangeSlider = ({
           blurRef.current.setAttribute('stdDeviation', `${down && active ? blurSize : 0}, 0`);
         });
       }
-
       setDraggedHandle(down ? 0 : -1);
       debouncedDrag();
       set({
@@ -501,7 +493,7 @@ export const RangeSlider = ({
         return (
           <StyledDragHandle
             // eslint-disable-next-line react/jsx-props-no-spreading
-            {...bind()}
+            {...isReadOnly ? {} : bind()}
             draggable={false}
             beingDragged={i === draggedHandle}
             style={{ x, y }}
@@ -510,6 +502,7 @@ export const RangeSlider = ({
             key={`handle${i}`}
             ref={dragHandleRef}
             {...dragHandleProps}
+            isReadOnly={isReadOnly}
           >
             {showHandleLabels && (
               <StyledHandleLabel value={value} ref={handleLabelRef} {...handleLabelProps}>

--- a/src/components/RangeSlider/RangeSlider.tsx
+++ b/src/components/RangeSlider/RangeSlider.tsx
@@ -24,7 +24,7 @@ import { useAccessibilityPreferences, useAnalytics, useTheme } from '../../conte
 import { StyledBaseDiv } from '../../htmlElements';
 
 export const Container = styled.div`
-  ${({ showDomainLabels, hasHandleLabels, disabled, beingDragged = false }: ContainerProps) => `
+  ${({ showDomainLabels, hasHandleLabels, disabled, beingDragged = false, maintainColorWhenDisabled = true}: ContainerProps) => `
     position: relative;
     height: 1rem;
     width: 100%;
@@ -39,8 +39,7 @@ export const Container = styled.div`
 
     ${
       disabled
-        ? `
-      filter: grayscale(1) contrast(.5) brightness(1.2);
+        ? ` ${maintainColorWhenDisabled ? '' : 'filter: grayscale(1) contrast(.5) brightness(1.2);'}
       pointer-events: none;
     `
         : ''
@@ -237,6 +236,7 @@ export const RangeSlider = ({
     console.log(newVal); // eslint-disable-line no-console
   },
   disabled = false,
+  maintainColorWhenDisabled = false,
   min,
   max,
   values,
@@ -439,6 +439,7 @@ export const RangeSlider = ({
     <StyledContainer
       data-test-id={['hs-ui-range-slider', testId].join('-')}
       disabled={disabled}
+      maintainColorWhenDisabled={maintainColorWhenDisabled}
       hasHandleLabels={hasHandleLabels}
       showHandleLabels={showHandleLabels}
       showDomainLabels={showDomainLabels}

--- a/src/components/RangeSlider/RangeSlider.tsx
+++ b/src/components/RangeSlider/RangeSlider.tsx
@@ -24,7 +24,7 @@ import { useAccessibilityPreferences, useAnalytics, useTheme } from '../../conte
 import { StyledBaseDiv } from '../../htmlElements';
 
 export const Container = styled.div`
-  ${({ showDomainLabels, hasHandleLabels, disabled, beingDragged = false, maintainColorWhenDisabled = true}: ContainerProps) => `
+  ${({ showDomainLabels, hasHandleLabels, disabled, beingDragged = false, isReadOnly = true}: ContainerProps) => `
     position: relative;
     height: 1rem;
     width: 100%;
@@ -39,9 +39,16 @@ export const Container = styled.div`
 
     ${
       disabled
-        ? ` ${maintainColorWhenDisabled ? '' : 'filter: grayscale(1) contrast(.5) brightness(1.2);'}
-      pointer-events: none;
-    `
+        ? `
+        filter: grayscale(1) contrast(.5) brightness(1.2);
+        pointer-events: none;`
+        : ''
+    }
+
+    ${
+      isReadOnly
+        ? `
+        pointer-events: none;`
         : ''
     }
 
@@ -236,7 +243,7 @@ export const RangeSlider = ({
     console.log(newVal); // eslint-disable-line no-console
   },
   disabled = false,
-  maintainColorWhenDisabled = false,
+  isReadOnly = false,
   min,
   max,
   values,
@@ -439,7 +446,7 @@ export const RangeSlider = ({
     <StyledContainer
       data-test-id={['hs-ui-range-slider', testId].join('-')}
       disabled={disabled}
-      maintainColorWhenDisabled={maintainColorWhenDisabled}
+      isReadOnly={isReadOnly}
       hasHandleLabels={hasHandleLabels}
       showHandleLabels={showHandleLabels}
       showDomainLabels={showDomainLabels}

--- a/src/components/RangeSlider/RangeSlider.tsx
+++ b/src/components/RangeSlider/RangeSlider.tsx
@@ -24,12 +24,7 @@ import { useAccessibilityPreferences, useAnalytics, useTheme } from '../../conte
 import { StyledBaseDiv } from '../../htmlElements';
 
 export const Container = styled.div`
-  ${({
-    showDomainLabels,
-    hasHandleLabels,
-    disabled,
-    beingDragged = false,
-  }: ContainerProps) => `
+  ${({ showDomainLabels, hasHandleLabels, disabled, beingDragged = false }: ContainerProps) => `
     position: relative;
     height: 1rem;
     width: 100%;
@@ -307,7 +302,9 @@ export const RangeSlider = ({
 
   const handleDrag = useCallback(
     (newVal: number) => {
-      if (readonly) { return; }
+      if (readonly) {
+        return;
+      }
       handleEventWithAnalytics(
         'RangeSlider',
         () => {
@@ -498,7 +495,7 @@ export const RangeSlider = ({
         return (
           <StyledDragHandle
             // eslint-disable-next-line react/jsx-props-no-spreading
-            {...readonly ? {} : bind()}
+            {...(readonly ? {} : bind())}
             draggable={false}
             beingDragged={i === draggedHandle}
             style={{ x, y }}

--- a/src/components/RangeSlider/RangeSlider.tsx
+++ b/src/components/RangeSlider/RangeSlider.tsx
@@ -101,12 +101,10 @@ export const HandleLabel = styled.div`
       bottom: 100%;
       left: 50%;
       transform: translateX(-50%) rotate(${clamp(velocity, -45, 45)}deg);
-
       background-color: ${colors.background};
       border-radius: 4px;
       font-weight: bold;
       white-space: nowrap;
-
       pointer-events: none;
       z-index: 2;
     `;

--- a/src/components/RangeSlider/RangeSlider.tsx
+++ b/src/components/RangeSlider/RangeSlider.tsx
@@ -24,7 +24,7 @@ import { useAccessibilityPreferences, useAnalytics, useTheme } from '../../conte
 import { StyledBaseDiv } from '../../htmlElements';
 
 export const Container = styled.div`
-  ${({ showDomainLabels, hasHandleLabels, disabled, beingDragged = false, isReadOnly = true}: ContainerProps) => `
+  ${({ showDomainLabels, hasHandleLabels, disabled, beingDragged = false, isReadOnly }: ContainerProps) => `
     position: relative;
     height: 1rem;
     width: 100%;

--- a/src/components/RangeSlider/RangeSlider.tsx
+++ b/src/components/RangeSlider/RangeSlider.tsx
@@ -73,7 +73,7 @@ export const Container = styled.div`
 `;
 
 export const DragHandle = styled(a.div)`
-  ${({ beingDragged = false, color, readOnly }: HandleProps) => {
+  ${({ beingDragged = false, color, readonly }: HandleProps) => {
     const { colors } = useTheme();
     const handleColor = color || colors.primary;
     return `
@@ -92,7 +92,7 @@ export const DragHandle = styled(a.div)`
       touch-action: none;
       filter: url(#blur);
       cursor: ${beingDragged ? 'grabbing' : 'grab'};
-      cursor: ${readOnly ? 'default' : ''};
+      cursor: ${readonly ? 'default' : ''};
       z-index: 2;
     `;
   }}
@@ -242,7 +242,7 @@ export const RangeSlider = ({
     console.log(newVal); // eslint-disable-line no-console
   },
   disabled = false,
-  readOnly = false,
+  readonly: readonly = false,
   min,
   max,
   values,
@@ -306,8 +306,9 @@ export const RangeSlider = ({
   const handleEventWithAnalytics = useAnalytics();
 
   const handleDrag = useCallback(
-    (newVal: number) =>
-      !readOnly && handleEventWithAnalytics(
+    (newVal: number) => {
+      if (readonly) {return}
+      handleEventWithAnalytics(
         'RangeSlider',
         () => {
           onDrag(newVal);
@@ -315,8 +316,10 @@ export const RangeSlider = ({
         'onDrag',
         { type: 'onDrag', newVal },
         containerProps,
-      ),
-    [handleEventWithAnalytics, onDrag, containerProps],
+      );
+    },
+
+    [handleEventWithAnalytics, onDrag, containerProps, readonly],
   );
 
   const finalDebounceInterval = prefersReducedMotion ? 0 : debounceInterval;
@@ -382,8 +385,10 @@ export const RangeSlider = ({
     },
     [slideRailProps, sliderBounds, handleDrag, domain, processedValues],
   );
-  const handleSlideRailClickWithAnalytics = (e: any) =>
+  const handleSlideRailClickWithAnalytics = (e: any) => {
+    if (readonly) return;
     handleEventWithAnalytics('RangeSlider', handleSlideRailClick, 'onClick', e, containerProps);
+  };
 
   const bind = useDrag(
     ({ active, down, movement: [deltaX, deltaY], vxvy: [vx] }) => {
@@ -444,7 +449,7 @@ export const RangeSlider = ({
     <StyledContainer
       data-test-id={['hs-ui-range-slider', testId].join('-')}
       disabled={disabled}
-      readOnly={readOnly}
+      readonly={readonly}
       hasHandleLabels={hasHandleLabels}
       showHandleLabels={showHandleLabels}
       showDomainLabels={showDomainLabels}
@@ -493,7 +498,7 @@ export const RangeSlider = ({
         return (
           <StyledDragHandle
             // eslint-disable-next-line react/jsx-props-no-spreading
-            {...readOnly ? {} : bind()}
+            {...readonly ? {} : bind()}
             draggable={false}
             beingDragged={i === draggedHandle}
             style={{ x, y }}
@@ -502,7 +507,7 @@ export const RangeSlider = ({
             key={`handle${i}`}
             ref={dragHandleRef}
             {...dragHandleProps}
-            readOnly={readOnly}
+            readonly={readonly}
           >
             {showHandleLabels && (
               <StyledHandleLabel value={value} ref={handleLabelRef} {...handleLabelProps}>

--- a/src/components/RangeSlider/RangeSlider.tsx
+++ b/src/components/RangeSlider/RangeSlider.tsx
@@ -73,7 +73,7 @@ export const Container = styled.div`
 `;
 
 export const DragHandle = styled(a.div)`
-  ${({ beingDragged = false, color, isReadOnly }: HandleProps) => {
+  ${({ beingDragged = false, color, readOnly }: HandleProps) => {
     const { colors } = useTheme();
     const handleColor = color || colors.primary;
     return `
@@ -92,7 +92,7 @@ export const DragHandle = styled(a.div)`
       touch-action: none;
       filter: url(#blur);
       cursor: ${beingDragged ? 'grabbing' : 'grab'};
-      cursor: ${isReadOnly ? 'default' : ''};
+      cursor: ${readOnly ? 'default' : ''};
       z-index: 2;
     `;
   }}
@@ -242,7 +242,7 @@ export const RangeSlider = ({
     console.log(newVal); // eslint-disable-line no-console
   },
   disabled = false,
-  isReadOnly = false,
+  readOnly = false,
   min,
   max,
   values,
@@ -307,7 +307,7 @@ export const RangeSlider = ({
 
   const handleDrag = useCallback(
     (newVal: number) =>
-      !isReadOnly && handleEventWithAnalytics(
+      !readOnly && handleEventWithAnalytics(
         'RangeSlider',
         () => {
           onDrag(newVal);
@@ -444,7 +444,7 @@ export const RangeSlider = ({
     <StyledContainer
       data-test-id={['hs-ui-range-slider', testId].join('-')}
       disabled={disabled}
-      isReadOnly={isReadOnly}
+      readOnly={readOnly}
       hasHandleLabels={hasHandleLabels}
       showHandleLabels={showHandleLabels}
       showDomainLabels={showDomainLabels}
@@ -493,7 +493,7 @@ export const RangeSlider = ({
         return (
           <StyledDragHandle
             // eslint-disable-next-line react/jsx-props-no-spreading
-            {...isReadOnly ? {} : bind()}
+            {...readOnly ? {} : bind()}
             draggable={false}
             beingDragged={i === draggedHandle}
             style={{ x, y }}
@@ -502,7 +502,7 @@ export const RangeSlider = ({
             key={`handle${i}`}
             ref={dragHandleRef}
             {...dragHandleProps}
-            isReadOnly={isReadOnly}
+            readOnly={readOnly}
           >
             {showHandleLabels && (
               <StyledHandleLabel value={value} ref={handleLabelRef} {...handleLabelProps}>

--- a/src/components/RangeSlider/RangeSlider.tsx
+++ b/src/components/RangeSlider/RangeSlider.tsx
@@ -24,7 +24,13 @@ import { useAccessibilityPreferences, useAnalytics, useTheme } from '../../conte
 import { StyledBaseDiv } from '../../htmlElements';
 
 export const Container = styled.div`
-  ${({ showDomainLabels, hasHandleLabels, disabled, beingDragged = false, isReadOnly }: ContainerProps) => `
+  ${({
+    showDomainLabels,
+    hasHandleLabels,
+    disabled,
+    beingDragged = false,
+    isReadOnly,
+  }: ContainerProps) => `
     position: relative;
     height: 1rem;
     width: 100%;

--- a/src/components/RangeSlider/RangeSlider.tsx
+++ b/src/components/RangeSlider/RangeSlider.tsx
@@ -242,7 +242,7 @@ export const RangeSlider = ({
     console.log(newVal); // eslint-disable-line no-console
   },
   disabled = false,
-  readonly: readonly = false,
+  readonly = false,
   min,
   max,
   values,
@@ -307,7 +307,7 @@ export const RangeSlider = ({
 
   const handleDrag = useCallback(
     (newVal: number) => {
-      if (readonly) {return}
+      if (readonly) { return; }
       handleEventWithAnalytics(
         'RangeSlider',
         () => {

--- a/src/components/RangeSlider/types.ts
+++ b/src/components/RangeSlider/types.ts
@@ -13,13 +13,13 @@ export type ContainerProps = {
   hasHandleLabels?: boolean;
   disabled: boolean;
   beingDragged: boolean;
-  readOnly: boolean;
+  readonly: boolean;
 };
 
 export type HandleProps = {
   beingDragged?: boolean;
   color: string;
-  readOnly: boolean;
+  readonly: boolean;
 };
 
 export type HandleLabelProps = { velocity?: number; showHandleLabels?: boolean };
@@ -70,7 +70,7 @@ export type RangeSliderProps = {
   axisLock?: 'x' | 'y' | '';
   onDrag?: (val: number) => void;
   disabled?: boolean;
-  readOnly?: boolean;
+  readonly?: boolean;
   min: number;
   max: number;
   values?: number[] | ValueProp[];

--- a/src/components/RangeSlider/types.ts
+++ b/src/components/RangeSlider/types.ts
@@ -19,6 +19,7 @@ export type ContainerProps = {
 export type HandleProps = {
   beingDragged?: boolean;
   color: string;
+  isReadOnly: boolean;
 };
 
 export type HandleLabelProps = { velocity?: number; showHandleLabels?: boolean };

--- a/src/components/RangeSlider/types.ts
+++ b/src/components/RangeSlider/types.ts
@@ -13,7 +13,7 @@ export type ContainerProps = {
   hasHandleLabels?: boolean;
   disabled: boolean;
   beingDragged: boolean;
-  maintainColorWhenDisabled: boolean;
+  isReadOnly: boolean;
 };
 
 export type HandleProps = {
@@ -69,7 +69,7 @@ export type RangeSliderProps = {
   axisLock?: 'x' | 'y' | '';
   onDrag?: (val: number) => void;
   disabled?: boolean;
-  maintainColorWhenDisabled?: boolean;
+  isReadOnly?: boolean;
   min: number;
   max: number;
   values?: number[] | ValueProp[];

--- a/src/components/RangeSlider/types.ts
+++ b/src/components/RangeSlider/types.ts
@@ -13,6 +13,7 @@ export type ContainerProps = {
   hasHandleLabels?: boolean;
   disabled: boolean;
   beingDragged: boolean;
+  maintainColorWhenDisabled: boolean;
 };
 
 export type HandleProps = {
@@ -68,6 +69,7 @@ export type RangeSliderProps = {
   axisLock?: 'x' | 'y' | '';
   onDrag?: (val: number) => void;
   disabled?: boolean;
+  maintainColorWhenDisabled?: boolean;
   min: number;
   max: number;
   values?: number[] | ValueProp[];

--- a/src/components/RangeSlider/types.ts
+++ b/src/components/RangeSlider/types.ts
@@ -13,13 +13,13 @@ export type ContainerProps = {
   hasHandleLabels?: boolean;
   disabled: boolean;
   beingDragged: boolean;
-  isReadOnly: boolean;
+  readOnly: boolean;
 };
 
 export type HandleProps = {
   beingDragged?: boolean;
   color: string;
-  isReadOnly: boolean;
+  readOnly: boolean;
 };
 
 export type HandleLabelProps = { velocity?: number; showHandleLabels?: boolean };
@@ -70,7 +70,7 @@ export type RangeSliderProps = {
   axisLock?: 'x' | 'y' | '';
   onDrag?: (val: number) => void;
   disabled?: boolean;
-  isReadOnly?: boolean;
+  readOnly?: boolean;
   min: number;
   max: number;
   values?: number[] | ValueProp[];


### PR DESCRIPTION
- This PR implements isReadOnly prop to the RangeSlider.
-This prop ensures that the RangeSlider cannot be used to change the value in readOnly mode.
- This feature can be really useful when implementing the RangeSlider and ensuring that only certain users can edit the value on the RangeSlider.