### PR TITLE
fix(spotlight, usescrollobserver): automatically scroll nearest scrollable element

### DIFF
--- a/src/components/Spotlight/Spotlight.tsx
+++ b/src/components/Spotlight/Spotlight.tsx
@@ -387,7 +387,7 @@ const Spotlight = ({
     prefersReducedMotion,
   ]);
 
-  /* Click */
+  /* onClick */
 
   const handleClick = (evt: MouseEvent) => {
     // TODO: Rename to onClickOutside?


### PR DESCRIPTION
Instead of always trying to scroll the window to highlight the target, it now finds the nearest
scrollable element and scrolls that instead. Many times, that will be the window/html element

fixes #481
