### PR TITLE
485: When Modal onClickOutside=false Esc key causes failure

### DIFF
--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -229,7 +229,7 @@ const Modal = forwardRef<ModalApi, ModalProps>(
 
     const escFunction = useCallback(
       (event: KeyboardEvent) => {
-        if (event.code === 'Escape') {
+        if (event.code === 'Escape' && onClickOutside) {
           animateClose(handleEsc, event);
         }
       },


### PR DESCRIPTION
Fix for issue #485 

When Modal onClickOutside=false, pressing the Esc key will cause the modal to be hidden when the expected behavior is that an Esc key press would do nothing.

Tests pass and no known issues have arisen. 