### PR TITLE
fix(table): default table sorting now correctly ignores capitalized letters in sort

### DIFF
--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -376,6 +376,14 @@ const Table = ({
     }
 
     // No sort function, use default comparison operator.
+    if (typeof entry1 === 'string' && typeof entry2 === 'string') {
+      const comparison =
+        sortDirection === SortDirection.ascending
+          ? entry1.toLocaleLowerCase() < entry2.toLocaleLowerCase()
+          : entry1.toLocaleLowerCase() > entry2.toLocaleLowerCase();
+      return comparison ? -1 : 1;
+    }
+
     const comparison =
       sortDirection === SortDirection.ascending ? entry1 < entry2 : entry1 > entry2;
     return comparison ? -1 : 1;


### PR DESCRIPTION
Previously, the table would put all capitalized words ahead of lowercased words

Fix #479
